### PR TITLE
fix: remove 0% entries from pie charts with 2 decimal precision

### DIFF
--- a/frontend/src/components/dashboard/CategoryBreakdown.tsx
+++ b/frontend/src/components/dashboard/CategoryBreakdown.tsx
@@ -22,13 +22,14 @@ const COLORS = [
 ];
 
 export const CategoryBreakdown = ({ data }: CategoryBreakdownProps) => {
-  // Transform data for Recharts
-  const chartData = data.map((item, index) => ({
-    name: item.category_name || 'Uncategorized',
-    value: parseFloat(item.total),
-    percentage: item.percentage,
-    color: COLORS[index % COLORS.length],
-  }));
+  const chartData = data
+    .filter((item) => item.percentage > 0)
+    .map((item, index) => ({
+      name: item.category_name || 'Uncategorized',
+      value: parseFloat(item.total),
+      percentage: item.percentage,
+      color: COLORS[index % COLORS.length],
+    }));
 
   // Custom tooltip
   const CustomTooltip = ({ active, payload }: { active?: boolean; payload?: any[] }) => {
@@ -43,7 +44,7 @@ export const CategoryBreakdown = ({ data }: CategoryBreakdownProps) => {
             {formatCurrency(dataPoint.value)}
           </Text>
           <Text fontSize="xs" color="fg.muted">
-            {dataPoint.payload.percentage.toFixed(1)}% of total
+            {dataPoint.payload.percentage.toFixed(2)}% of total
           </Text>
         </Box>
       );
@@ -51,9 +52,9 @@ export const CategoryBreakdown = ({ data }: CategoryBreakdownProps) => {
     return null;
   };
 
-  // Custom label for pie slices
+  // Custom label for pie slices with 2 decimal precision
   const renderLabel = (entry: any) => {
-    return `${entry.percentage.toFixed(0)}%`;
+    return `${entry.percentage.toFixed(2)}%`;
   };
 
   if (chartData.length === 0) {

--- a/frontend/src/components/reports/MonthlyReport.tsx
+++ b/frontend/src/components/reports/MonthlyReport.tsx
@@ -50,11 +50,13 @@ export const MonthlyReport = ({ transactions, categoryBreakdown }: MonthlyReport
 
   const categoryPieData = useMemo(
     () =>
-      categoryBreakdown.map((cat, index) => ({
-        name: cat.category_name || 'Uncategorized',
-        value: Math.abs(parseFloat(cat.total)),
-        color: colors[index % colors.length],
-      })),
+      categoryBreakdown
+        .filter((cat) => cat.percentage > 0)
+        .map((cat, index) => ({
+          name: cat.category_name || 'Uncategorized',
+          value: Math.abs(parseFloat(cat.total)),
+          color: colors[index % colors.length],
+        })),
     [categoryBreakdown, colors]
   );
 


### PR DESCRIPTION
Filters out categories with percentage > 0 from both pie charts and displays percentages with 2 decimal precision for better accuracy.

## Changes
- Updated [`CategoryBreakdown.tsx`](frontend/src/components/dashboard/CategoryBreakdown.tsx) to filter categories with `percentage > 0` and show 2 decimal places
- Updated [`MonthlyReport.tsx`](frontend/src/components/reports/MonthlyReport.tsx) to filter categories with `percentage > 0`
- Changed percentage labels from 0 decimals (e.g., "0%") to 2 decimals (e.g., "0.37%") for better precision

## Testing
✅ Tested in browser using Docker
✅ Console logs confirm filtering is working correctly
✅ Categories with very small percentages (like 0.37%) now display accurately
✅ No console errors
✅ Charts render correctly

## Example
Before: Category with 0.37% showed as "0%"
After: Category with 0.37% shows as "0.37%"

Closes #29