### PR TITLE
fix: replace category color code text with colored bar (fixes #60)

### DIFF
--- a/frontend/src/components/categories/CategoryCard.tsx
+++ b/frontend/src/components/categories/CategoryCard.tsx
@@ -1,4 +1,4 @@
-import { Card, HStack, VStack, Text, IconButton, Badge } from '@chakra-ui/react';
+import { Box, Card, HStack, VStack, Text, IconButton } from '@chakra-ui/react';
 import { LuPencil, LuTrash2 } from 'react-icons/lu';
 import type { Category } from '@/types';
 
@@ -19,24 +19,24 @@ export const CategoryCard = ({ category, onClick, onEdit, onDelete }: CategoryCa
     >
       <Card.Body>
         <HStack justify="space-between" align="start">
-          <HStack gap={3} flex={1}>
-            {/* Category Icon */}
+          <HStack gap={3} flex={1} align="stretch">
+            <Box
+              width="4px"
+              borderRadius="full"
+              bg={category.color}
+              alignSelf="stretch"
+              flexShrink={0}
+            />
             <Text fontSize="2xl">{category.icon}</Text>
 
-            {/* Category Details */}
             <VStack align="start" gap={1} flex={1}>
               <Text fontWeight="semibold" fontSize="lg">
                 {category.name}
               </Text>
-              <HStack gap={2}>
-                <Badge colorPalette="gray" size="sm" style={{ backgroundColor: category.color }}>
-                  {category.color}
-                </Badge>
-                <Text fontSize="sm" color="fg.muted">
-                  {category.transaction_count} transaction
-                  {category.transaction_count !== 1 ? 's' : ''}
-                </Text>
-              </HStack>
+              <Text fontSize="sm" color="fg.muted">
+                {category.transaction_count} transaction
+                {category.transaction_count !== 1 ? 's' : ''}
+              </Text>
             </VStack>
           </HStack>
 


### PR DESCRIPTION
## Description
Replaces the color hex code text (previously shown as a Badge next to each category) with a small rounded vertical colored bar on the left side of the category card. This removes visual clutter while still communicating the category color.

## Related Issues
Fixes #60

## Changes
- `frontend/src/components/categories/CategoryCard.tsx`: Replace the Badge rendering `category.color` as text with a 4px-wide rounded `Box` using `category.color` as its background; drop the now-unused `Badge` import and add `Box`.

## Testing
- Full Playwright E2E suite (119 passed, 1 skipped) run via pre-commit hook after `docker-compose down && build && up -d`.
- Visual verification via `screenshots/actual/categories-list.png`: colored bar now appears to the left of each category, hex code text is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)