### PR TITLE
feat: add uncategorised option to transaction filters

### DIFF
--- a/frontend/src/components/transactions/TransactionFilters.tsx
+++ b/frontend/src/components/transactions/TransactionFilters.tsx
@@ -1,6 +1,12 @@
 import { Box, Button, HStack, Input, Text, VStack, Checkbox, Stack } from '@chakra-ui/react';
 import type { Account, Category } from '@/types';
 
+/**
+ * Sentinel value used in `categoryIds` to represent transactions that have no category.
+ * Chosen to not collide with any UUID so it round-trips safely through URL params.
+ */
+export const UNCATEGORISED_FILTER_ID = 'uncategorised';
+
 export interface TransactionFilterValues {
   accountIds: string[];
   categoryIds: string[];
@@ -196,30 +202,41 @@ export const TransactionFilters = ({
       )}
 
       {/* Categories */}
-      {categories.length > 0 && (
-        <Box>
-          <Text fontSize="sm" fontWeight="medium" mb={2}>
-            Categories
-          </Text>
-          <Stack gap={2} maxH="150px" overflowY="auto">
-            {categories.map((category) => (
-              <Checkbox.Root
-                key={category.id}
-                checked={filters.categoryIds.includes(category.id)}
-                onCheckedChange={() => handleCategoryToggle(category.id)}
-              >
-                <Checkbox.HiddenInput />
-                <Checkbox.Control />
-                <Checkbox.Label>
-                  <Text fontSize="sm">
-                    {category.icon} {category.name}
-                  </Text>
-                </Checkbox.Label>
-              </Checkbox.Root>
-            ))}
-          </Stack>
-        </Box>
-      )}
+      <Box>
+        <Text fontSize="sm" fontWeight="medium" mb={2}>
+          Categories
+        </Text>
+        <Stack gap={2} maxH="150px" overflowY="auto">
+          <Checkbox.Root
+            key={UNCATEGORISED_FILTER_ID}
+            checked={filters.categoryIds.includes(UNCATEGORISED_FILTER_ID)}
+            onCheckedChange={() => handleCategoryToggle(UNCATEGORISED_FILTER_ID)}
+          >
+            <Checkbox.HiddenInput />
+            <Checkbox.Control />
+            <Checkbox.Label>
+              <Text fontSize="sm" fontStyle="italic" color="fg.muted">
+                Uncategorised
+              </Text>
+            </Checkbox.Label>
+          </Checkbox.Root>
+          {categories.map((category) => (
+            <Checkbox.Root
+              key={category.id}
+              checked={filters.categoryIds.includes(category.id)}
+              onCheckedChange={() => handleCategoryToggle(category.id)}
+            >
+              <Checkbox.HiddenInput />
+              <Checkbox.Control />
+              <Checkbox.Label>
+                <Text fontSize="sm">
+                  {category.icon} {category.name}
+                </Text>
+              </Checkbox.Label>
+            </Checkbox.Root>
+          ))}
+        </Stack>
+      </Box>
     </VStack>
   );
 };

--- a/frontend/src/hooks/usecase/useAccountDetail.ts
+++ b/frontend/src/hooks/usecase/useAccountDetail.ts
@@ -4,7 +4,10 @@ import useTransactions from '@/hooks/api/useTransactions';
 import useEnrichedTransactions from '@/hooks/api/useEnrichedTransactions';
 import useCategories from '@/hooks/api/useCategories';
 import useDeleteAccount from '@/hooks/api/useDeleteAccount';
-import type { TransactionFilterValues } from '@/components/transactions/TransactionFilters';
+import {
+  UNCATEGORISED_FILTER_ID,
+  type TransactionFilterValues,
+} from '@/components/transactions/TransactionFilters';
 
 const DEFAULT_FILTERS: TransactionFilterValues = {
   accountIds: [],
@@ -52,12 +55,12 @@ export default function useAccountDetail(id: string) {
     if (!enrichedTransactions) return [];
 
     return enrichedTransactions.filter((transaction) => {
-      // Category filter
-      if (
-        filters.categoryIds.length > 0 &&
-        (!transaction.category || !filters.categoryIds.includes(transaction.category.id))
-      ) {
-        return false;
+      // Category filter (supports a sentinel for uncategorised transactions)
+      if (filters.categoryIds.length > 0) {
+        const matches = transaction.category
+          ? filters.categoryIds.includes(transaction.category.id)
+          : filters.categoryIds.includes(UNCATEGORISED_FILTER_ID);
+        if (!matches) return false;
       }
 
       // Transaction type filter

--- a/frontend/src/hooks/usecase/useBudgetDetail.ts
+++ b/frontend/src/hooks/usecase/useBudgetDetail.ts
@@ -5,7 +5,10 @@ import useEnrichedTransactions from '@/hooks/api/useEnrichedTransactions';
 import useAccounts from '@/hooks/api/useAccounts';
 import useCategories from '@/hooks/api/useCategories';
 import useDeleteBudget from '@/hooks/api/useDeleteBudget';
-import type { TransactionFilterValues } from '@/components/transactions/TransactionFilters';
+import {
+  UNCATEGORISED_FILTER_ID,
+  type TransactionFilterValues,
+} from '@/components/transactions/TransactionFilters';
 
 const DEFAULT_FILTERS: TransactionFilterValues = {
   accountIds: [],
@@ -79,12 +82,12 @@ export default function useBudgetDetail(id: string) {
         return false;
       }
 
-      // Category filter
-      if (
-        filters.categoryIds.length > 0 &&
-        (!transaction.category || !filters.categoryIds.includes(transaction.category.id))
-      ) {
-        return false;
+      // Category filter (supports a sentinel for uncategorised transactions)
+      if (filters.categoryIds.length > 0) {
+        const matches = transaction.category
+          ? filters.categoryIds.includes(transaction.category.id)
+          : filters.categoryIds.includes(UNCATEGORISED_FILTER_ID);
+        if (!matches) return false;
       }
 
       // Transaction type filter

--- a/frontend/src/hooks/usecase/usePersonDetail.ts
+++ b/frontend/src/hooks/usecase/usePersonDetail.ts
@@ -5,7 +5,10 @@ import useEnrichedTransactions from '@/hooks/api/useEnrichedTransactions';
 import useAccounts from '@/hooks/api/useAccounts';
 import useCategories from '@/hooks/api/useCategories';
 import useDeletePerson from '@/hooks/api/useDeletePerson';
-import type { TransactionFilterValues } from '@/components/transactions/TransactionFilters';
+import {
+  UNCATEGORISED_FILTER_ID,
+  type TransactionFilterValues,
+} from '@/components/transactions/TransactionFilters';
 
 const DEFAULT_FILTERS: TransactionFilterValues = {
   accountIds: [],
@@ -61,12 +64,12 @@ export default function usePersonDetail(id: string) {
         return false;
       }
 
-      // Category filter
-      if (
-        filters.categoryIds.length > 0 &&
-        (!transaction.category || !filters.categoryIds.includes(transaction.category.id))
-      ) {
-        return false;
+      // Category filter (supports a sentinel for uncategorised transactions)
+      if (filters.categoryIds.length > 0) {
+        const matches = transaction.category
+          ? filters.categoryIds.includes(transaction.category.id)
+          : filters.categoryIds.includes(UNCATEGORISED_FILTER_ID);
+        if (!matches) return false;
       }
 
       // Transaction type filter

--- a/frontend/src/pages/Transactions.tsx
+++ b/frontend/src/pages/Transactions.tsx
@@ -11,6 +11,7 @@ import {
   TransferFormModal,
 } from '@/components/transactions';
 import { ImportStatementModal } from '@/components/transactions/import';
+import { UNCATEGORISED_FILTER_ID } from '@/components/transactions/TransactionFilters';
 import {
   useTransactions,
   useEnrichedTransactions,
@@ -112,12 +113,12 @@ export const TransactionsPage = () => {
         return false;
       }
 
-      // Category filter
-      if (
-        filters.categoryIds.length > 0 &&
-        (!transaction.category || !filters.categoryIds.includes(transaction.category.id))
-      ) {
-        return false;
+      // Category filter (supports a sentinel for uncategorised transactions)
+      if (filters.categoryIds.length > 0) {
+        const matches = transaction.category
+          ? filters.categoryIds.includes(transaction.category.id)
+          : filters.categoryIds.includes(UNCATEGORISED_FILTER_ID);
+        if (!matches) return false;
       }
 
       // Transaction type filter


### PR DESCRIPTION
## Summary
- Adds an "Uncategorised" option to the category filter on the transactions page (and to the shared filter component used by Account/Budget/Person detail pages) so transactions with no category can be isolated.
- Filtering is client-side, matching the existing behaviour of the category filter. A sentinel value `UNCATEGORISED_FILTER_ID` lives alongside the real category IDs in `categoryIds[]` and round-trips through the `categories` URL param.

## Related Issues
Fixes #62

## Test plan
- [x] TypeScript compiles (`npx tsc --noEmit`)
- [x] Pre-commit e2e suite passes (119 tests, 1 skipped)
- [x] Visually verified the option renders in the filter drawer
- [ ] Manually toggle "Uncategorised" with and without other categories selected to confirm combined behaviour