### PR TITLE
fix: roll monthly budgets to current calendar month

### DIFF
--- a/backend/src/services/budget_service.rs
+++ b/backend/src/services/budget_service.rs
@@ -1,5 +1,5 @@
 use bigdecimal::BigDecimal;
-use chrono::Utc;
+use chrono::{NaiveDate, Utc};
 use std::str::FromStr;
 use uuid::Uuid;
 use validator::Validate;
@@ -9,11 +9,28 @@ use crate::{
     errors::ApiError,
     models::{
         BudgetRangeResponse, BudgetResponse, CreateBudgetRangeRequest, CreateBudgetRequest,
-        NewBudget, NewBudgetRange, UpdateBudgetRequest,
+        NewBudget, NewBudgetRange, UpdateBudgetRequest, budget_range::BudgetRange,
     },
     repositories,
     services::exchange_rate_service::ExchangeRateProvider,
 };
+
+/// Compute the current active period window for a budget range.
+///
+/// Returns `(start, end)` clamped to the range's own `start_date`/`end_date`
+/// so the window never extends outside the budget's lifetime.
+fn current_period_window(range: &BudgetRange, today: NaiveDate) -> (NaiveDate, NaiveDate) {
+    let (mut start, mut end) = range.period.current_window(today);
+    if start < range.start_date {
+        start = range.start_date;
+    }
+    if let Some(range_end) = range.end_date
+        && end > range_end
+    {
+        end = range_end;
+    }
+    (start, end)
+}
 
 /// Budget status information
 #[derive(Debug, serde::Serialize)]
@@ -93,10 +110,12 @@ pub async fn get_budget(
             .and_then(|v| v.as_str())
             .and_then(|s| Uuid::parse_str(s).ok());
 
-        let start_date = Some(range.start_date.and_hms_opt(0, 0, 0).unwrap().and_utc());
-        let end_date = range
-            .end_date
-            .map(|d| d.and_hms_opt(23, 59, 59).unwrap().and_utc());
+        // Narrow the range's stored bounds to the calendar-aligned period
+        // containing today (e.g. MONTHLY → 1st → last day of current month),
+        // so spending resets at each period boundary.
+        let (window_start, window_end) = current_period_window(&range, today);
+        let start_date = Some(window_start.and_hms_opt(0, 0, 0).unwrap().and_utc());
+        let end_date = Some(window_end.and_hms_opt(23, 59, 59).unwrap().and_utc());
 
         // Single query: compute split-adjusted spending grouped by currency
         let spending_by_currency = repositories::budget::calculate_spending_by_currency(
@@ -128,7 +147,12 @@ pub async fn get_budget(
             0.0
         };
 
-        response.active_range = Some(range.into());
+        // Return the current period window (not the raw stored range) so clients
+        // filter transactions to the same window the spending total reflects.
+        let mut range_response: BudgetRangeResponse = range.into();
+        range_response.start_date = window_start;
+        range_response.end_date = Some(window_end);
+        response.active_range = Some(range_response);
         response.current_spending = Some(spending_abs.to_string());
         response.percentage_used = Some(percentage_used);
     }
@@ -308,10 +332,9 @@ pub async fn calculate_budget_status(
         .and_then(|v| v.as_str())
         .and_then(|s| Uuid::parse_str(s).ok());
 
-    let start_date = Some(range.start_date.and_hms_opt(0, 0, 0).unwrap().and_utc());
-    let end_date = range
-        .end_date
-        .map(|d| d.and_hms_opt(23, 59, 59).unwrap().and_utc());
+    let (window_start, window_end) = current_period_window(&range, today);
+    let start_date = Some(window_start.and_hms_opt(0, 0, 0).unwrap().and_utc());
+    let end_date = Some(window_end.and_hms_opt(23, 59, 59).unwrap().and_utc());
 
     // Single query: compute split-adjusted spending grouped by currency
     let spending_by_currency = repositories::budget::calculate_spending_by_currency(

--- a/backend/src/types/budget_period.rs
+++ b/backend/src/types/budget_period.rs
@@ -1,3 +1,4 @@
+use chrono::{Datelike, Days, Months, NaiveDate, Weekday};
 use diesel::deserialize::{self, FromSql};
 use diesel::pg::Pg;
 use diesel::serialize::{self, Output, ToSql};
@@ -23,6 +24,54 @@ pub enum BudgetPeriod {
     Monthly,
     Quarterly,
     Yearly,
+}
+
+impl BudgetPeriod {
+    /// Compute the calendar-aligned window containing `today`.
+    ///
+    /// Returns `(start, end)` for the period that `today` falls into:
+    /// - Daily: (today, today)
+    /// - Weekly: Monday → Sunday of the current ISO week
+    /// - Monthly: 1st → last day of the current month
+    /// - Quarterly: first day of the current quarter → last day of the current quarter
+    /// - Yearly: Jan 1 → Dec 31 of the current year
+    pub fn current_window(&self, today: NaiveDate) -> (NaiveDate, NaiveDate) {
+        match self {
+            BudgetPeriod::Daily => (today, today),
+            BudgetPeriod::Weekly => {
+                // ISO week: Monday = 0 .. Sunday = 6
+                let days_from_monday = today.weekday().num_days_from_monday() as u64;
+                let start = today.checked_sub_days(Days::new(days_from_monday)).unwrap();
+                let end = start.checked_add_days(Days::new(6)).unwrap();
+                debug_assert_eq!(start.weekday(), Weekday::Mon);
+                (start, end)
+            }
+            BudgetPeriod::Monthly => {
+                let start = NaiveDate::from_ymd_opt(today.year(), today.month(), 1).unwrap();
+                let end = start
+                    .checked_add_months(Months::new(1))
+                    .unwrap()
+                    .checked_sub_days(Days::new(1))
+                    .unwrap();
+                (start, end)
+            }
+            BudgetPeriod::Quarterly => {
+                let quarter_start_month = ((today.month() - 1) / 3) * 3 + 1;
+                let start = NaiveDate::from_ymd_opt(today.year(), quarter_start_month, 1).unwrap();
+                let end = start
+                    .checked_add_months(Months::new(3))
+                    .unwrap()
+                    .checked_sub_days(Days::new(1))
+                    .unwrap();
+                (start, end)
+            }
+            BudgetPeriod::Yearly => {
+                let start = NaiveDate::from_ymd_opt(today.year(), 1, 1).unwrap();
+                let end = NaiveDate::from_ymd_opt(today.year(), 12, 31).unwrap();
+                (start, end)
+            }
+        }
+    }
 }
 
 impl ToSql<crate::schema::sql_types::BudgetPeriod, Pg> for BudgetPeriod {

--- a/backend/tests/integration/api/test_budget_spending.rs
+++ b/backend/tests/integration/api/test_budget_spending.rs
@@ -213,6 +213,152 @@ async fn test_budget_spending_accounts_for_splits() {
     );
 }
 
+/// Test that a MONTHLY budget rolls over to the current calendar month, even
+/// when its range was created in a prior month with `end_date` that still
+/// covers today.
+///
+/// This exercises the regression where a range created on (e.g.) April 23 with
+/// end_date May 23 was being treated as the "current period" for the entire
+/// span — so May transactions and April transactions were summed together, and
+/// the budget never reset on May 1.
+///
+/// After the fix:
+/// - `active_range.start_date` / `active_range.end_date` returned to the
+///   client must reflect the current calendar month, not the raw stored range.
+/// - `current_spending` must only include transactions dated in the current month.
+#[tokio::test]
+async fn test_monthly_budget_rolls_over_to_current_month() {
+    use chrono::{Duration, TimeZone};
+
+    let server = create_test_server().await;
+    let timestamp = Utc::now().timestamp_nanos_opt().unwrap();
+
+    let auth = register_test_user(
+        &server,
+        &format!("budgetrollover_{}", timestamp),
+        &format!("budgetrollover_{}@example.com", timestamp),
+        "SecurePass123!",
+        "Budget Rollover User",
+    )
+    .await;
+
+    let account = create_eur_account(&server, &auth.token, "EUR Checking").await;
+    let category = create_test_category(&server, &auth.token, "Groceries").await;
+
+    // Create a budget whose range was created roughly a month ago and spans
+    // into today — e.g. range start = today - 45 days, end = today + 15 days,
+    // so the raw range covers the previous calendar month AND the current one.
+    let budget_request = json!({
+        "name": "Monthly Groceries",
+        "filters": { "category_id": category.id.to_string() }
+    });
+    let budget_response =
+        post_authenticated(&server, "/api/v1/budgets", &auth.token, &budget_request).await;
+    assert_status(&budget_response, 201);
+    let budget: BudgetResponse = extract_json(budget_response);
+
+    let today = Utc::now().date_naive();
+    let range_start = today - Duration::days(45);
+    let range_end = today + Duration::days(15);
+    let range_request = json!({
+        "limit_amount": 200.0,
+        "period": "MONTHLY",
+        "start_date": range_start.to_string(),
+        "end_date": range_end.to_string(),
+    });
+    let range_resp = post_authenticated(
+        &server,
+        &format!("/api/v1/budgets/{}/ranges", budget.id),
+        &auth.token,
+        &range_request,
+    )
+    .await;
+    assert_status(&range_resp, 201);
+
+    // Seed two transactions:
+    // 1. one ~35 days ago (previous calendar month in most positions in the year)
+    // 2. one today (current month)
+    let prev_month_date = Utc
+        .from_utc_datetime(&(today - Duration::days(35)).and_hms_opt(12, 0, 0).unwrap())
+        .to_rfc3339();
+    let txn_old = json!({
+        "account_id": account.id,
+        "category_id": category.id,
+        "title": "Groceries — previous month",
+        "amount": -80.0,
+        "date": prev_month_date,
+    });
+    assert_status(
+        &post_authenticated(&server, "/api/v1/transactions", &auth.token, &txn_old).await,
+        201,
+    );
+
+    let txn_now = json!({
+        "account_id": account.id,
+        "category_id": category.id,
+        "title": "Groceries — today",
+        "amount": -25.0,
+        "date": Utc::now().to_rfc3339(),
+    });
+    assert_status(
+        &post_authenticated(&server, "/api/v1/transactions", &auth.token, &txn_now).await,
+        201,
+    );
+
+    // Fetch the budget — its active_range must be the current calendar month,
+    // and spending must exclude the older transaction.
+    let detail_resp = get_authenticated(
+        &server,
+        &format!("/api/v1/budgets/{}", budget.id),
+        &auth.token,
+    )
+    .await;
+    assert_status(&detail_resp, 200);
+    let detail: BudgetResponse = extract_json(detail_resp);
+
+    let active_range = detail
+        .active_range
+        .expect("budget should have an active range");
+
+    // Compute expected calendar-month window for `today`.
+    use chrono::{Datelike, NaiveDate};
+    let expected_start = NaiveDate::from_ymd_opt(today.year(), today.month(), 1).unwrap();
+    let expected_end = if today.month() == 12 {
+        NaiveDate::from_ymd_opt(today.year() + 1, 1, 1).unwrap()
+    } else {
+        NaiveDate::from_ymd_opt(today.year(), today.month() + 1, 1).unwrap()
+    }
+    .pred_opt()
+    .unwrap();
+
+    // If the raw range happens to end mid-month (because end = today + 15d),
+    // it should clamp to min(calendar month end, range end).
+    let expected_end_clamped = expected_end.min(range_end);
+
+    assert_eq!(
+        active_range.start_date, expected_start,
+        "active_range.start_date should be the 1st of the current month (was {})",
+        active_range.start_date
+    );
+    assert_eq!(
+        active_range.end_date,
+        Some(expected_end_clamped),
+        "active_range.end_date should be last day of current month (clamped to range end)"
+    );
+
+    let spending: f64 = detail
+        .current_spending
+        .as_ref()
+        .expect("current_spending")
+        .parse()
+        .unwrap();
+    assert!(
+        (spending - 25.0).abs() < 0.01,
+        "spending should only include this month's €25 transaction, got {}",
+        spending
+    );
+}
+
 /// Test that budget spending is correct when a transaction has NO splits.
 ///
 /// Scenario:

--- a/backend/tests/integration/database/mod.rs
+++ b/backend/tests/integration/database/mod.rs
@@ -15,6 +15,7 @@ mod common;
 mod test_api_key_crud;
 mod test_async_bridge;
 mod test_background_jobs;
+mod test_budget_period;
 mod test_connection;
 mod test_cron_utils;
 mod test_custom_types;

--- a/backend/tests/integration/database/test_budget_period.rs
+++ b/backend/tests/integration/database/test_budget_period.rs
@@ -1,0 +1,86 @@
+//! Tests for `BudgetPeriod::current_window` — the calendar-aligned period
+//! helper used by the budget service to decide which transactions fall into
+//! the *current* period (vs. the range's full lifetime).
+
+use chrono::NaiveDate;
+use master_of_coin_backend::types::BudgetPeriod;
+
+fn ymd(y: i32, m: u32, d: u32) -> NaiveDate {
+    NaiveDate::from_ymd_opt(y, m, d).unwrap()
+}
+
+#[test]
+fn daily_window_is_single_day() {
+    let today = ymd(2026, 5, 9);
+    assert_eq!(BudgetPeriod::Daily.current_window(today), (today, today));
+}
+
+#[test]
+fn weekly_window_runs_monday_to_sunday() {
+    // 2026-05-09 is a Saturday
+    let (start, end) = BudgetPeriod::Weekly.current_window(ymd(2026, 5, 9));
+    assert_eq!(start, ymd(2026, 5, 4)); // Monday
+    assert_eq!(end, ymd(2026, 5, 10)); // Sunday
+}
+
+#[test]
+fn weekly_window_on_monday_starts_today() {
+    // 2026-05-04 is a Monday
+    let (start, end) = BudgetPeriod::Weekly.current_window(ymd(2026, 5, 4));
+    assert_eq!(start, ymd(2026, 5, 4));
+    assert_eq!(end, ymd(2026, 5, 10));
+}
+
+#[test]
+fn monthly_window_is_first_to_last_of_month() {
+    // The original bug: a May date should yield the May window, not an
+    // April-anchored one, regardless of when the budget was created.
+    let (start, end) = BudgetPeriod::Monthly.current_window(ymd(2026, 5, 9));
+    assert_eq!(start, ymd(2026, 5, 1));
+    assert_eq!(end, ymd(2026, 5, 31));
+}
+
+#[test]
+fn monthly_window_handles_february_and_leap_years() {
+    // Non-leap February (2026)
+    let (start, end) = BudgetPeriod::Monthly.current_window(ymd(2026, 2, 15));
+    assert_eq!(start, ymd(2026, 2, 1));
+    assert_eq!(end, ymd(2026, 2, 28));
+
+    // Leap February (2028)
+    let (start, end) = BudgetPeriod::Monthly.current_window(ymd(2028, 2, 15));
+    assert_eq!(start, ymd(2028, 2, 1));
+    assert_eq!(end, ymd(2028, 2, 29));
+}
+
+#[test]
+fn monthly_window_handles_december_rollover() {
+    let (start, end) = BudgetPeriod::Monthly.current_window(ymd(2026, 12, 20));
+    assert_eq!(start, ymd(2026, 12, 1));
+    assert_eq!(end, ymd(2026, 12, 31));
+}
+
+#[test]
+fn quarterly_window_buckets_into_calendar_quarters() {
+    // Q1: Jan–Mar
+    let (start, end) = BudgetPeriod::Quarterly.current_window(ymd(2026, 2, 10));
+    assert_eq!(start, ymd(2026, 1, 1));
+    assert_eq!(end, ymd(2026, 3, 31));
+
+    // Q2: Apr–Jun
+    let (start, end) = BudgetPeriod::Quarterly.current_window(ymd(2026, 5, 9));
+    assert_eq!(start, ymd(2026, 4, 1));
+    assert_eq!(end, ymd(2026, 6, 30));
+
+    // Q4: Oct–Dec
+    let (start, end) = BudgetPeriod::Quarterly.current_window(ymd(2026, 11, 1));
+    assert_eq!(start, ymd(2026, 10, 1));
+    assert_eq!(end, ymd(2026, 12, 31));
+}
+
+#[test]
+fn yearly_window_is_whole_calendar_year() {
+    let (start, end) = BudgetPeriod::Yearly.current_window(ymd(2026, 5, 9));
+    assert_eq!(start, ymd(2026, 1, 1));
+    assert_eq!(end, ymd(2026, 12, 31));
+}


### PR DESCRIPTION
## Summary
- Fixes #64: MONTHLY budgets were showing prior-month transactions because the stored `BudgetRange` bounds (e.g. Apr 23 → May 23) were used as the active window instead of a calendar-aligned one.
- New `BudgetPeriod::current_window(today)` returns calendar-aligned windows (day / ISO week / month / quarter / year).
- `budget_service` now clamps the window to the range's own bounds and returns it via `active_range.start_date`/`end_date`, so both the spending calc *and* the frontend transaction filter (which already reads those fields) pick up the corrected window automatically — no frontend change needed.

## Test plan
- [x] `cargo test --test integration_database test_budget_period` — 8 unit tests for `current_window` (daily, weekly, Feb + leap year, December rollover, quarterly buckets, yearly)
- [x] `cargo test --test integration_api test_budget_spending` — existing 6 tests green + new `test_monthly_budget_rolls_over_to_current_month` confirms mid-month range → May window after rollover
- [x] `cargo test --test integration_api test_budgets` — all 30 budget API tests still pass
- [x] Full `cargo test --test integration_api` — 382 passed, 0 failed
- [x] Manual check in the app that the dashboard now shows only the current month's transactions under Monthly Groceries

🤖 Generated with [Claude Code](https://claude.com/claude-code)