### PR TITLE
fix: keep Splitwise friends with null name or email

### DIFF
--- a/backend/src/handlers/split_providers.rs
+++ b/backend/src/handlers/split_providers.rs
@@ -158,11 +158,35 @@ async fn fetch_splitwise_friends(
     let friends: Vec<SplitwiseFriendResponse> = friends_array
         .iter()
         .filter_map(|friend| {
-            let id = friend.get("id")?.as_i64()?;
-            let first_name = friend.get("first_name")?.as_str()?.to_string();
-            let last_name = friend.get("last_name")?.as_str()?.to_string();
-            let email = friend.get("email")?.as_str()?.to_string();
-            let full_name = format!("{} {}", first_name, last_name);
+            // Only `id` is required (it's the mapping key to person_split_configs).
+            // Splitwise legitimately returns null for first_name/last_name/email
+            // (e.g. a friend added with only a first name, or no registered email),
+            // so tolerate missing/null values instead of silently dropping the friend.
+            let Some(id) = friend.get("id").and_then(|v| v.as_i64()) else {
+                tracing::warn!(
+                    friend = ?friend,
+                    "Skipping Splitwise friend with missing or invalid id"
+                );
+                return None;
+            };
+            let first_name = friend
+                .get("first_name")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
+            let last_name = friend
+                .get("last_name")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
+            let email = friend
+                .get("email")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
+            let full_name = format!("{} {}", first_name, last_name)
+                .trim()
+                .to_string();
 
             Some(SplitwiseFriendResponse {
                 id,


### PR DESCRIPTION
## Problem

`GET /api/v1/integrations/providers/{id}/friends` was silently dropping Splitwise friends who have a `null` `first_name`, `last_name`, or `email`. Splitwise legitimately returns `last_name: null` for a contact added with only a first name (and `email: null` for friends without a registered email).

The parse used `filter_map` with `friend.get("last_name")?.as_str()?` — when the field is JSON `null`, `.as_str()` returns `None`, the `?` short-circuits, and the whole friend is discarded with no error or log. This is why the friend "Jeyadev" (a single-name contact with a valid email) was missing from the response, even when hitting the raw API URL directly.

## Fix

In `fetch_splitwise_friends` (`backend/src/handlers/split_providers.rs`):
- Keep only `id` required (it's the mapping key to `person_split_configs.external_user_id`), and emit a `tracing::warn!` when a friend is skipped for a missing/invalid id, so future silent drops are visible in logs.
- Tolerate missing/null `first_name`, `last_name`, and `email` by defaulting to `""`.
- Build `full_name` with a `.trim()` so a missing last name doesn't leave a trailing space.

This mirrors how the SplitPro path in the same file already tolerates empty name/email.

## Scope

Backend parse bug only. A separate, unrelated issue (the frontend friends list uses React Query's 5-minute `staleTime` with no invalidation) is intentionally **not** included here.

## Testing

`cargo check` passes cleanly (only pre-existing, unrelated warnings).