### PR TITLE
feat: add skip_split_sync flag to transaction create

### DIFF
--- a/backend/migrations/2026-07-17-230842-0000_add_sync_skipped_to_transaction_splits/down.sql
+++ b/backend/migrations/2026-07-17-230842-0000_add_sync_skipped_to_transaction_splits/down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE transaction_splits DROP COLUMN IF EXISTS sync_skipped;

--- a/backend/migrations/2026-07-17-230842-0000_add_sync_skipped_to_transaction_splits/up.sql
+++ b/backend/migrations/2026-07-17-230842-0000_add_sync_skipped_to_transaction_splits/up.sql
@@ -1,0 +1,5 @@
+-- Marks a split whose upstream provider (e.g. Splitwise) sync was intentionally
+-- skipped at transaction-create time. Distinguishes "deliberately not synced"
+-- from "not yet synced". Defaults to FALSE to preserve existing behaviour.
+ALTER TABLE transaction_splits
+    ADD COLUMN sync_skipped BOOLEAN NOT NULL DEFAULT FALSE;

--- a/backend/src/handlers/transactions.rs
+++ b/backend/src/handlers/transactions.rs
@@ -41,10 +41,19 @@ pub async fn create(
     let user_id = auth_context.user_id();
     tracing::info!("Creating transaction for user {}", user_id);
 
+    // Read the skip flag before `request` is moved into the service.
+    let skip_split_sync = request.skip_split_sync;
+
     let transaction = transaction_service::create_transaction(&state.db, user_id, request).await?;
 
-    // Trigger split sync if splits were created (fire-and-forget)
-    if let Some(ref splits) = transaction.splits {
+    // Trigger split sync if splits were created (fire-and-forget), unless the
+    // caller explicitly opted out via skip_split_sync.
+    if skip_split_sync {
+        tracing::info!(
+            "Skipping split sync for transaction {} (skip_split_sync=true)",
+            transaction.id
+        );
+    } else if let Some(ref splits) = transaction.splits {
         if !splits.is_empty() {
             trigger_split_sync(state.split_sync.clone(), transaction.id).await;
         }

--- a/backend/src/models/transaction.rs
+++ b/backend/src/models/transaction.rs
@@ -100,6 +100,12 @@ pub struct CreateTransactionRequest {
     /// Each split must have a positive amount, and total splits must not exceed transaction amount
     #[validate(nested)]
     pub splits: Option<Vec<TransactionSplitInput>>,
+
+    /// When true, splits are recorded in MOC but the automatic upstream
+    /// split-provider (e.g. Splitwise) sync is skipped. Defaults to false,
+    /// preserving the existing behaviour of syncing on create.
+    #[serde(default)]
+    pub skip_split_sync: bool,
 }
 
 // Custom validator for amount not being zero

--- a/backend/src/models/transaction_split.rs
+++ b/backend/src/models/transaction_split.rs
@@ -17,6 +17,9 @@ pub struct TransactionSplit {
     pub amount: BigDecimal,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
+    /// True when this split's upstream provider (e.g. Splitwise) sync was
+    /// intentionally skipped at create time (distinct from "not yet synced").
+    pub sync_skipped: bool,
 }
 
 #[derive(Debug, Insertable)]
@@ -25,6 +28,7 @@ pub struct NewTransactionSplit {
     pub transaction_id: Uuid,
     pub person_id: Uuid,
     pub amount: BigDecimal,
+    pub sync_skipped: bool,
 }
 
 #[derive(Debug, Deserialize)]
@@ -104,6 +108,8 @@ pub struct TransactionSplitResponse {
     pub person_id: Uuid,
     /// BigDecimal as string for JSON serialization
     pub amount: String,
+    /// True when this split's upstream provider sync was intentionally skipped.
+    pub sync_skipped: bool,
 }
 
 impl From<TransactionSplit> for TransactionSplitResponse {
@@ -112,6 +118,7 @@ impl From<TransactionSplit> for TransactionSplitResponse {
             id: split.id,
             person_id: split.person_id,
             amount: format!("{:.2}", split.amount),
+            sync_skipped: split.sync_skipped,
         }
     }
 }

--- a/backend/src/schema.rs
+++ b/backend/src/schema.rs
@@ -287,6 +287,7 @@ diesel::table! {
         amount -> Numeric,
         created_at -> Timestamptz,
         updated_at -> Timestamptz,
+        sync_skipped -> Bool,
     }
 }
 

--- a/backend/src/services/debt_service.rs
+++ b/backend/src/services/debt_service.rs
@@ -170,6 +170,7 @@ pub async fn settle_debt(
         transaction_id: transaction.id,
         person_id,
         amount: split_amount,
+        sync_skipped: false,
     };
 
     repositories::transaction::create_split(pool, transaction.id, new_split).await?;

--- a/backend/src/services/debt_transaction_service.rs
+++ b/backend/src/services/debt_transaction_service.rs
@@ -150,6 +150,7 @@ pub async fn create_debt_transaction(
         transaction_id: transaction.id,
         person_id: request.payer_person_id,
         amount,
+        sync_skipped: false,
     };
     let split = repositories::transaction::create_split(pool, transaction.id, new_split).await?;
 

--- a/backend/src/services/split_sync_service.rs
+++ b/backend/src/services/split_sync_service.rs
@@ -2109,6 +2109,7 @@ impl SplitSyncService {
             transaction_id: transaction.id,
             person_id: payer_person_id,
             amount: amount.clone(),
+            sync_skipped: false,
         };
         let split =
             repositories::transaction::create_split(&self.pool, transaction.id, new_split).await?;
@@ -2244,6 +2245,7 @@ impl SplitSyncService {
                 transaction_id: transaction.id,
                 person_id,
                 amount: split_amount,
+                sync_skipped: false,
             };
 
             let split =

--- a/backend/src/services/transaction_service.rs
+++ b/backend/src/services/transaction_service.rs
@@ -140,6 +140,7 @@ pub async fn create_transaction(
                 transaction_id: transaction.id,
                 person_id: split_input.person_id,
                 amount: signed_split_amount,
+                sync_skipped: request.skip_split_sync,
             };
 
             let split =
@@ -450,6 +451,9 @@ pub async fn update_transaction(
                     transaction_id,
                     person_id: split_input.person_id,
                     amount: signed_split_amount,
+                    // Update path is out of scope for the skip-sync flag; keep
+                    // the default (not skipped).
+                    sync_skipped: false,
                 };
                 let split =
                     repositories::transaction::create_split(pool, transaction_id, new_split)

--- a/backend/tests/integration/api/test_transactions.rs
+++ b/backend/tests/integration/api/test_transactions.rs
@@ -507,6 +507,109 @@ async fn test_create_transaction_with_splits() {
 
     let splits = transaction.splits.unwrap();
     assert_eq!(splits.len(), 2);
+
+    // Default behaviour: splits are not marked as sync-skipped.
+    assert!(splits.iter().all(|s| !s.sync_skipped));
+}
+
+/// Test that creating a transaction with `skip_split_sync: true` records the
+/// splits normally but marks them as sync-skipped (so no upstream provider
+/// sync is triggered).
+#[tokio::test]
+async fn test_create_transaction_with_splits_skip_sync() {
+    let server = create_test_server().await;
+    let timestamp = Utc::now().timestamp_nanos_opt().unwrap();
+
+    let auth = register_test_user(
+        &server,
+        &format!("skipsyncuser_{}", timestamp),
+        &format!("skipsync_{}@example.com", timestamp),
+        "SecurePass123!",
+        "Skip Sync Test User",
+    )
+    .await;
+
+    let account = create_test_account(&server, &auth.token, "Test Account").await;
+    let category = create_test_category(&server, &auth.token, "Test Category").await;
+    let person = create_test_person(&server, &auth.token, "Person 1").await;
+
+    let request = json!({
+        "account_id": account.id,
+        "category_id": category.id,
+        "title": "Already Settled Expense",
+        "amount": -100.00,
+        "date": Utc::now().to_rfc3339(),
+        "skip_split_sync": true,
+        "splits": [
+            {
+                "person_id": person.id,
+                "amount": 40.00
+            }
+        ]
+    });
+
+    let response = post_authenticated(&server, "/api/v1/transactions", &auth.token, &request).await;
+    assert_status(&response, 201);
+
+    let transaction: TransactionResponse = extract_json(response);
+    let splits = transaction.splits.expect("splits should be present");
+    assert_eq!(splits.len(), 1);
+    // The split is stored and flagged as intentionally not synced.
+    assert!(splits.iter().all(|s| s.sync_skipped));
+
+    // The split is still readable via GET (persisted normally).
+    let get_response = get_authenticated(
+        &server,
+        &format!("/api/v1/transactions/{}", transaction.id),
+        &auth.token,
+    )
+    .await;
+    assert_status(&get_response, 200);
+    let fetched: TransactionResponse = extract_json(get_response);
+    let fetched_splits = fetched.splits.expect("splits should be present on GET");
+    assert_eq!(fetched_splits.len(), 1);
+    assert!(fetched_splits[0].sync_skipped);
+}
+
+/// Test that omitting `skip_split_sync` defaults to false (existing behaviour).
+#[tokio::test]
+async fn test_create_transaction_skip_sync_defaults_false() {
+    let server = create_test_server().await;
+    let timestamp = Utc::now().timestamp_nanos_opt().unwrap();
+
+    let auth = register_test_user(
+        &server,
+        &format!("defaultsyncuser_{}", timestamp),
+        &format!("defaultsync_{}@example.com", timestamp),
+        "SecurePass123!",
+        "Default Sync Test User",
+    )
+    .await;
+
+    let account = create_test_account(&server, &auth.token, "Test Account").await;
+    let person = create_test_person(&server, &auth.token, "Person 1").await;
+
+    // No skip_split_sync field in the payload.
+    let request = json!({
+        "account_id": account.id,
+        "title": "Shared Expense",
+        "amount": -100.00,
+        "date": Utc::now().to_rfc3339(),
+        "splits": [
+            {
+                "person_id": person.id,
+                "amount": 30.00
+            }
+        ]
+    });
+
+    let response = post_authenticated(&server, "/api/v1/transactions", &auth.token, &request).await;
+    assert_status(&response, 201);
+
+    let transaction: TransactionResponse = extract_json(response);
+    let splits = transaction.splits.expect("splits should be present");
+    assert_eq!(splits.len(), 1);
+    assert!(!splits[0].sync_skipped);
 }
 
 /// Test that list transactions includes splits for transactions with splits.


### PR DESCRIPTION
## Summary

Adds an opt-in `skip_split_sync` flag to the **create-transaction** payload. When set, MOC records the split rows normally but does **not** trigger the automatic Splitwise/split-provider sync (no upstream expense is created). Default is `false`, so existing behaviour is unchanged.

Use case: recording a split in MOC for internal tracking when it's already settled on Splitwise, to avoid creating a duplicate expense.

## Behaviour

- New field `skip_split_sync: bool` on `CreateTransactionRequest` (snake_case, `#[serde(default)]` → omitting it means `false` = sync ON, as today).
- When `true`, the fire-and-forget `trigger_split_sync` call in the create handler is skipped.
- Each created split is persisted with a new `sync_skipped` marker so an intentionally-skipped split is distinguishable from a not-yet-synced one.
- **Create path only** — the update path is untouched (splits created via update keep `sync_skipped = false`).
- The background worker never auto-discovers unsynced splits (there is no SplitSync job type), so simply not triggering sync is sufficient — a skipped split won't be re-synced later.

## Changes

- **Migration** `add_sync_skipped_to_transaction_splits`: adds `sync_skipped BOOLEAN NOT NULL DEFAULT FALSE` to `transaction_splits`. Verified up + down apply cleanly against a fresh Postgres 16.
- `models/transaction.rs`: new `skip_split_sync` request field.
- `models/transaction_split.rs`: `sync_skipped` on `TransactionSplit`, `NewTransactionSplit`, and exposed on `TransactionSplitResponse`.
- `handlers/transactions.rs`: gate the split-sync trigger on the flag.
- `services/transaction_service.rs`: propagate the flag onto created splits (create path); update path sets `false`.
- Other `NewTransactionSplit` construction sites (debt/import/re-sync) set `sync_skipped: false` to preserve current behaviour.
- `schema.rs` updated for the new column.

## Testing

- `cargo build` and `cargo test --no-run` pass (only pre-existing warnings).
- Migration up/down verified on a throwaway Postgres 16 (column is `boolean NOT NULL default false`).
- New API tests in `test_transactions.rs`:
  - `test_create_transaction_with_splits_skip_sync` — splits stored + marked `sync_skipped`, and still readable via GET.
  - `test_create_transaction_skip_sync_defaults_false` — omitting the flag defaults to `false`.
  - extended `test_create_transaction_with_splits` to assert the default is `false`.

## Notes

Full integration suite requires a Postgres test DB (runs in CI / pre-commit); I verified compilation and the migration rather than running it against the live DB.