### PR TITLE
feat: convert an existing transaction into a transfer

### DIFF
--- a/backend/src/api/routes.rs
+++ b/backend/src/api/routes.rs
@@ -187,6 +187,21 @@ pub fn create_router(state: AppState) -> Router {
                 )
             })),
         )
+        // Convert an existing transaction into a transfer
+        .route(
+            "/transactions/:id/convert-to-transfer",
+            post(handlers::transfers::convert_to_transfer).layer(middleware::from_fn(
+                |auth, req, next| {
+                    require_scope(
+                        ResourceType::Transactions,
+                        OperationType::Write,
+                        auth,
+                        req,
+                        next,
+                    )
+                },
+            )),
+        )
         // Debt transactions (paid by others)
         .route(
             "/debt-transactions",

--- a/backend/src/handlers/transfers.rs
+++ b/backend/src/handlers/transfers.rs
@@ -2,14 +2,15 @@ use crate::{
     AppState,
     auth::context::AuthContext,
     errors::ApiError,
-    models::transfer::{CreateTransferRequest, TransferResponse},
+    models::transfer::{ConvertToTransferRequest, CreateTransferRequest, TransferResponse},
     services::transfer_service,
 };
 use axum::{
     Json,
-    extract::{Extension, State},
+    extract::{Extension, Path, State},
     http::StatusCode,
 };
+use uuid::Uuid;
 
 /// Create a new transfer between two accounts
 /// POST /transfers
@@ -22,6 +23,32 @@ pub async fn create(
     tracing::info!("Creating transfer for user {}", user_id);
 
     let transfer = transfer_service::create_transfer(&state.db, user_id, request).await?;
+
+    Ok((StatusCode::CREATED, Json(transfer)))
+}
+
+/// Convert an existing transaction into a transfer
+/// POST /transactions/:id/convert-to-transfer
+pub async fn convert_to_transfer(
+    State(state): State<AppState>,
+    Extension(auth_context): Extension<AuthContext>,
+    Path(transaction_id): Path<Uuid>,
+    Json(request): Json<ConvertToTransferRequest>,
+) -> Result<(StatusCode, Json<TransferResponse>), ApiError> {
+    let user_id = auth_context.user_id();
+    tracing::info!(
+        "Converting transaction {} into a transfer for user {}",
+        transaction_id,
+        user_id
+    );
+
+    let transfer = transfer_service::convert_transaction_to_transfer(
+        &state.db,
+        user_id,
+        transaction_id,
+        request,
+    )
+    .await?;
 
     Ok((StatusCode::CREATED, Json(transfer)))
 }

--- a/backend/src/models/transfer.rs
+++ b/backend/src/models/transfer.rs
@@ -46,6 +46,24 @@ pub struct CreateTransferRequest {
     pub category_id: Option<Uuid>,
 }
 
+/// Request DTO for converting an existing transaction into a transfer.
+///
+/// The transaction to convert is identified by the path; the caller supplies
+/// the counterpart account. Direction is inferred from the original
+/// transaction's amount sign (negative = money left the original account, so
+/// the counterpart is the destination; positive = money arrived, so the
+/// counterpart is the source), so it never needs to be stated.
+#[derive(Debug, Deserialize, Validate)]
+pub struct ConvertToTransferRequest {
+    /// The counterpart account for the other leg of the transfer.
+    pub account_id: Uuid,
+    /// For cross-currency conversions: the absolute amount on the counterpart
+    /// account's leg. Ignored when both accounts share a currency.
+    pub counterpart_amount: Option<f64>,
+    /// Alternative to `counterpart_amount` for cross-currency conversions.
+    pub exchange_rate: Option<f64>,
+}
+
 /// Response DTO — what the API returns after creating a transfer.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct TransferResponse {

--- a/backend/src/repositories/transfer.rs
+++ b/backend/src/repositories/transfer.rs
@@ -66,6 +66,65 @@ pub async fn create_transfer_atomic(
     })?
 }
 
+/// Atomically join an existing transaction into a transfer.
+///
+/// The original transaction (`original_transaction_id`) is left untouched. Only
+/// the opposite leg (`new_leg`) and the linking `transfers` row are inserted,
+/// both inside one `conn.transaction()` so a partial failure rolls back
+/// entirely — there is no half-converted state. The caller resolves direction
+/// and passes the correct `from`/`to` assignment via `original_is_source`.
+pub async fn join_transaction_into_transfer_atomic(
+    pool: &DbPool,
+    original_transaction_id: Uuid,
+    original_is_source: bool,
+    new_leg: NewTransaction,
+    exchange_rate: BigDecimal,
+) -> Result<(Transfer, Transaction), ApiError> {
+    let mut conn = pool.get().map_err(|e| {
+        tracing::error!("Failed to get DB connection: {}", e);
+        ApiError::Internal
+    })?;
+
+    tokio::task::spawn_blocking(move || {
+        conn.transaction(|conn| {
+            // 1. Insert the new opposite leg.
+            let new_transaction: Transaction = diesel::insert_into(transactions::table)
+                .values(&new_leg)
+                .get_result(conn)?;
+
+            // 2. Assign from/to slots. The from (source) leg is the negative
+            //    side, the to (destination) leg the positive side.
+            let (from_transaction_id, to_transaction_id) = if original_is_source {
+                (original_transaction_id, new_transaction.id)
+            } else {
+                (new_transaction.id, original_transaction_id)
+            };
+
+            // 3. Insert the transfer row linking both transactions.
+            let new_transfer = NewTransfer {
+                from_transaction_id,
+                to_transaction_id,
+                exchange_rate,
+            };
+
+            let transfer: Transfer = diesel::insert_into(transfers::table)
+                .values(&new_transfer)
+                .get_result(conn)?;
+
+            Ok((transfer, new_transaction))
+        })
+        .map_err(|e: diesel::result::Error| {
+            tracing::error!("Failed to convert transaction to transfer atomically: {}", e);
+            ApiError::from(e)
+        })
+    })
+    .await
+    .map_err(|e| {
+        tracing::error!("Task join error: {}", e);
+        ApiError::Internal
+    })?
+}
+
 /// Find a transfer by either of its linked transaction IDs.
 ///
 /// Returns `None` if the transaction is not part of a transfer.

--- a/backend/src/services/transfer_service.rs
+++ b/backend/src/services/transfer_service.rs
@@ -8,7 +8,7 @@ use crate::{
     errors::ApiError,
     models::{
         NewTransaction, TransactionResponse,
-        transfer::{CreateTransferRequest, TransferResponse},
+        transfer::{ConvertToTransferRequest, CreateTransferRequest, TransferResponse},
     },
     repositories,
 };
@@ -172,6 +172,203 @@ pub async fn create_transfer(
     // 12. Build TransferResponse
     let from_response = TransactionResponse::from(from_transaction);
     let to_response = TransactionResponse::from(to_transaction);
+
+    Ok(TransferResponse {
+        id: transfer.id,
+        from_transaction: from_response,
+        to_transaction: to_response,
+        exchange_rate: format!("{}", transfer.exchange_rate),
+        created_at: transfer.created_at,
+    })
+}
+
+/// Convert an existing normal transaction into a transfer.
+///
+/// The original transaction is kept as-is and becomes one leg; a new opposite
+/// leg is created on the chosen counterpart account, and both are linked via a
+/// `transfers` row — producing a transfer indistinguishable from a native one.
+///
+/// Direction is inferred from the original amount's sign:
+/// - original **negative** (money left the original account) → original is the
+///   source/from leg, the counterpart is the destination (new leg positive).
+/// - original **positive** (money arrived) → original is the destination/to
+///   leg, the counterpart is the source (new leg negative).
+///
+/// The original transaction's category is preserved on the new leg (never
+/// overwritten). Refuses when the transaction has splits, is already part of a
+/// transfer, has a zero amount, or the counterpart account equals the
+/// original's account. All inserts happen in one DB transaction.
+pub async fn convert_transaction_to_transfer(
+    pool: &DbPool,
+    user_id: Uuid,
+    transaction_id: Uuid,
+    request: ConvertToTransferRequest,
+) -> Result<TransferResponse, ApiError> {
+    // 1. Load the original transaction and verify ownership.
+    let original = repositories::transaction::find_by_id(pool, transaction_id)
+        .await?
+        .transaction;
+    if original.user_id != user_id {
+        tracing::warn!(
+            "User {} attempted to convert transaction {} owned by {}",
+            user_id,
+            transaction_id,
+            original.user_id
+        );
+        return Err(ApiError::Unauthorized(
+            "Transaction does not belong to user".to_string(),
+        ));
+    }
+
+    // 2. Refuse if the transaction is soft-deleted.
+    if original.is_deleted {
+        return Err(ApiError::Validation(
+            "Cannot convert a deleted transaction into a transfer".to_string(),
+        ));
+    }
+
+    // 3. Refuse if the transaction already belongs to a transfer.
+    if repositories::transfer::find_transfer_by_transaction_id(pool, transaction_id)
+        .await?
+        .is_some()
+    {
+        return Err(ApiError::Validation(
+            "Transaction is already part of a transfer".to_string(),
+        ));
+    }
+
+    // 4. Refuse if the transaction has splits (a split cannot become a transfer).
+    let splits = repositories::transaction::list_splits_for_transaction(pool, transaction_id).await?;
+    if !splits.is_empty() {
+        return Err(ApiError::Validation(
+            "Cannot convert a transaction with splits into a transfer. Remove the splits first."
+                .to_string(),
+        ));
+    }
+
+    // 5. Refuse zero-amount (no meaningful direction).
+    let zero = BigDecimal::from(0);
+    if original.amount == zero {
+        return Err(ApiError::Validation(
+            "Cannot convert a zero-amount transaction into a transfer".to_string(),
+        ));
+    }
+
+    // 6. Counterpart account must be different from the original's account and owned by the user.
+    if request.account_id == original.account_id {
+        return Err(ApiError::Validation(
+            "Counterpart account must be different from the transaction's account".to_string(),
+        ));
+    }
+    let original_account = repositories::account::find_by_id(pool, original.account_id).await?;
+    let counterpart_account = repositories::account::find_by_id(pool, request.account_id).await?;
+    if counterpart_account.user_id != user_id {
+        tracing::warn!(
+            "User {} attempted to convert using counterpart account {} owned by {}",
+            user_id,
+            request.account_id,
+            counterpart_account.user_id
+        );
+        return Err(ApiError::Unauthorized(
+            "Account does not belong to user".to_string(),
+        ));
+    }
+
+    // 7. Direction from sign. `original_is_source` == original amount is negative.
+    let original_is_source = original.amount < zero;
+
+    // 8. Resolve the counterpart leg's amount (and the transfer's exchange rate).
+    // The original leg keeps its own signed amount; the new leg gets the opposite sign.
+    let original_abs = original.amount.abs();
+    let original_abs_f64 = f64::from_str(&original_abs.to_string()).map_err(|e| {
+        tracing::error!("Failed to parse original amount: {}", e);
+        ApiError::Internal
+    })?;
+
+    let same_currency = original_account.currency == counterpart_account.currency;
+    let (counterpart_abs, exchange_rate) = if same_currency {
+        (original_abs.clone(), 1.0_f64)
+    } else if let Some(amt) = request.counterpart_amount {
+        if amt <= 0.0 {
+            return Err(ApiError::Validation(
+                "counterpart_amount must be positive".to_string(),
+            ));
+        }
+        let rate = amt / original_abs_f64;
+        let amt_bd = BigDecimal::from_str(&format!("{}", amt))
+            .map_err(|_| ApiError::Validation("Invalid counterpart_amount".to_string()))?;
+        (amt_bd, rate)
+    } else if let Some(rate) = request.exchange_rate {
+        if rate <= 0.0 {
+            return Err(ApiError::Validation(
+                "exchange_rate must be positive".to_string(),
+            ));
+        }
+        let amt_bd = BigDecimal::from_str(&format!("{}", original_abs_f64 * rate))
+            .map_err(|_| ApiError::Validation("Invalid exchange_rate".to_string()))?;
+        (amt_bd, rate)
+    } else {
+        return Err(ApiError::Validation(
+            "Cross-currency conversion requires either counterpart_amount or exchange_rate"
+                .to_string(),
+        ));
+    };
+
+    let exchange_rate_bd = BigDecimal::from_str(&format!("{}", exchange_rate))
+        .map_err(|_| ApiError::Validation("Invalid exchange_rate".to_string()))?;
+
+    // 9. Build the new opposite leg. Sign is opposite the original: if the
+    // original is the source (negative), the new counterpart leg is positive
+    // (inflow), and vice versa. Category is preserved from the original.
+    let new_leg_amount = if original_is_source {
+        counterpart_abs // positive inflow on destination
+    } else {
+        -counterpart_abs // negative outflow on source
+    };
+
+    let new_leg_title = if original_is_source {
+        format!("Transfer from {}", original_account.name)
+    } else {
+        format!("Transfer to {}", original_account.name)
+    };
+
+    let new_leg = NewTransaction {
+        user_id,
+        account_id: counterpart_account.id,
+        category_id: original.category_id,
+        title: new_leg_title,
+        amount: new_leg_amount,
+        date: original.date,
+        notes: original.notes.clone(),
+    };
+
+    // 10. Atomically insert the new leg + the transfers row.
+    let (transfer, new_transaction) =
+        repositories::transfer::join_transaction_into_transfer_atomic(
+            pool,
+            original.id,
+            original_is_source,
+            new_leg,
+            exchange_rate_bd,
+        )
+        .await?;
+
+    tracing::info!(
+        "Converted transaction {} into transfer {} for user {} (counterpart account {})",
+        original.id,
+        transfer.id,
+        user_id,
+        counterpart_account.id
+    );
+
+    // 11. Build the response with the legs in from/to order.
+    let original_response = TransactionResponse::from(original);
+    let new_response = TransactionResponse::from(new_transaction);
+    let (from_response, to_response) = if original_is_source {
+        (original_response, new_response)
+    } else {
+        (new_response, original_response)
+    };
 
     Ok(TransferResponse {
         id: transfer.id,

--- a/backend/tests/integration/api/test_transfers.rs
+++ b/backend/tests/integration/api/test_transfers.rs
@@ -592,3 +592,260 @@ async fn test_list_transactions_includes_transfer_info() {
         "to-side transfer_info should have the checking account name"
     );
 }
+
+// ============================================================================
+// Convert-to-transfer Tests
+// ============================================================================
+
+/// Helper: create a normal transaction and return its JSON.
+async fn create_normal_transaction(
+    server: &axum_test::TestServer,
+    token: &str,
+    account_id: uuid::Uuid,
+    amount: f64,
+    extra: serde_json::Value,
+) -> TransactionResponse {
+    let mut request = json!({
+        "account_id": account_id,
+        "title": "To convert",
+        "amount": amount,
+        "date": Utc::now().to_rfc3339(),
+    });
+    if let Some(obj) = extra.as_object() {
+        for (k, v) in obj {
+            request[k] = v.clone();
+        }
+    }
+    let response = post_authenticated(server, "/api/v1/transactions", token, &request).await;
+    assert_status(&response, 201);
+    extract_json(response)
+}
+
+/// A NEGATIVE (debit) transaction converts with the counterpart as the
+/// DESTINATION: original stays the from-leg, new positive leg on the counterpart.
+#[tokio::test]
+async fn test_convert_debit_counterpart_is_destination() {
+    let server = create_test_server().await;
+    let timestamp = Utc::now().timestamp_nanos_opt().unwrap();
+    let auth = register_test_user(
+        &server,
+        &format!("conv_debit_{}", timestamp),
+        &format!("conv_debit_{}@example.com", timestamp),
+        "SecurePass123!",
+        "Convert Debit User",
+    )
+    .await;
+
+    let source = create_account_with_currency(&server, &auth.token, "EUR Source", "EUR").await;
+    let dest = create_account_with_currency(&server, &auth.token, "EUR Dest", "EUR").await;
+
+    // A -100 debit on `source`.
+    let txn = create_normal_transaction(&server, &auth.token, source.id, -100.0, json!({})).await;
+
+    let request = json!({ "account_id": dest.id });
+    let response = post_authenticated(
+        &server,
+        &format!("/api/v1/transactions/{}/convert-to-transfer", txn.id),
+        &auth.token,
+        &request,
+    )
+    .await;
+    assert_status(&response, 201);
+    let transfer: TransferResponse = extract_json(response);
+
+    // Original (the -100 on source) is the from-leg.
+    assert_eq!(transfer.from_transaction.id, txn.id);
+    assert_eq!(transfer.from_transaction.account_id, source.id);
+    assert_eq!(transfer.from_transaction.amount, "-100.00");
+    // New leg is +100 on the destination account.
+    assert_eq!(transfer.to_transaction.account_id, dest.id);
+    assert_eq!(transfer.to_transaction.amount, "100.00");
+    assert_eq!(transfer.exchange_rate, "1");
+
+    // The transaction now reports transfer_info when fetched.
+    let get = get_authenticated(
+        &server,
+        &format!("/api/v1/transactions/{}", txn.id),
+        &auth.token,
+    )
+    .await;
+    assert_status(&get, 200);
+    let fetched: TransactionResponse = extract_json(get);
+    assert!(
+        fetched.transfer_info.is_some(),
+        "converted transaction should carry transfer_info"
+    );
+}
+
+/// A POSITIVE (credit) transaction converts with the counterpart as the SOURCE:
+/// original becomes the to-leg, new negative leg on the counterpart.
+#[tokio::test]
+async fn test_convert_credit_counterpart_is_source() {
+    let server = create_test_server().await;
+    let timestamp = Utc::now().timestamp_nanos_opt().unwrap();
+    let auth = register_test_user(
+        &server,
+        &format!("conv_credit_{}", timestamp),
+        &format!("conv_credit_{}@example.com", timestamp),
+        "SecurePass123!",
+        "Convert Credit User",
+    )
+    .await;
+
+    let dest = create_account_with_currency(&server, &auth.token, "EUR Dest", "EUR").await;
+    let source = create_account_with_currency(&server, &auth.token, "EUR Source", "EUR").await;
+
+    // A +100 credit on `dest`.
+    let txn = create_normal_transaction(&server, &auth.token, dest.id, 100.0, json!({})).await;
+
+    let request = json!({ "account_id": source.id });
+    let response = post_authenticated(
+        &server,
+        &format!("/api/v1/transactions/{}/convert-to-transfer", txn.id),
+        &auth.token,
+        &request,
+    )
+    .await;
+    assert_status(&response, 201);
+    let transfer: TransferResponse = extract_json(response);
+
+    // New leg is the -100 source; original +100 is the to-leg.
+    assert_eq!(transfer.from_transaction.account_id, source.id);
+    assert_eq!(transfer.from_transaction.amount, "-100.00");
+    assert_eq!(transfer.to_transaction.id, txn.id);
+    assert_eq!(transfer.to_transaction.account_id, dest.id);
+    assert_eq!(transfer.to_transaction.amount, "100.00");
+}
+
+/// The original transaction's category is preserved (not overwritten).
+#[tokio::test]
+async fn test_convert_preserves_category() {
+    let server = create_test_server().await;
+    let timestamp = Utc::now().timestamp_nanos_opt().unwrap();
+    let auth = register_test_user(
+        &server,
+        &format!("conv_cat_{}", timestamp),
+        &format!("conv_cat_{}@example.com", timestamp),
+        "SecurePass123!",
+        "Convert Category User",
+    )
+    .await;
+
+    let source = create_account_with_currency(&server, &auth.token, "EUR Source", "EUR").await;
+    let dest = create_account_with_currency(&server, &auth.token, "EUR Dest", "EUR").await;
+    let category = create_test_category(&server, &auth.token, "Groceries").await;
+
+    let txn = create_normal_transaction(
+        &server,
+        &auth.token,
+        source.id,
+        -50.0,
+        json!({ "category_id": category.id }),
+    )
+    .await;
+
+    let request = json!({ "account_id": dest.id });
+    let response = post_authenticated(
+        &server,
+        &format!("/api/v1/transactions/{}/convert-to-transfer", txn.id),
+        &auth.token,
+        &request,
+    )
+    .await;
+    assert_status(&response, 201);
+    let transfer: TransferResponse = extract_json(response);
+
+    // Original leg keeps its category.
+    assert_eq!(
+        transfer.from_transaction.category_id,
+        Some(category.id),
+        "original leg should keep its category"
+    );
+    // New leg inherits the same category.
+    assert_eq!(
+        transfer.to_transaction.category_id,
+        Some(category.id),
+        "new leg should inherit the original category"
+    );
+}
+
+/// A transaction with splits cannot be converted — API returns a validation error.
+#[tokio::test]
+async fn test_convert_with_splits_refused() {
+    let server = create_test_server().await;
+    let timestamp = Utc::now().timestamp_nanos_opt().unwrap();
+    let auth = register_test_user(
+        &server,
+        &format!("conv_splits_{}", timestamp),
+        &format!("conv_splits_{}@example.com", timestamp),
+        "SecurePass123!",
+        "Convert Splits User",
+    )
+    .await;
+
+    let source = create_account_with_currency(&server, &auth.token, "EUR Source", "EUR").await;
+    let dest = create_account_with_currency(&server, &auth.token, "EUR Dest", "EUR").await;
+    let person = create_test_person(&server, &auth.token, "Alex").await;
+
+    // -100 expense with a split.
+    let txn = create_normal_transaction(
+        &server,
+        &auth.token,
+        source.id,
+        -100.0,
+        json!({ "splits": [ { "person_id": person.id, "amount": 40.0 } ] }),
+    )
+    .await;
+
+    let request = json!({ "account_id": dest.id });
+    let response = post_authenticated(
+        &server,
+        &format!("/api/v1/transactions/{}/convert-to-transfer", txn.id),
+        &auth.token,
+        &request,
+    )
+    .await;
+    // Validation error (splits present) → 422 Unprocessable Entity.
+    assert_status(&response, 422);
+}
+
+/// A transaction already part of a transfer cannot be converted again.
+#[tokio::test]
+async fn test_convert_already_transfer_refused() {
+    let server = create_test_server().await;
+    let timestamp = Utc::now().timestamp_nanos_opt().unwrap();
+    let auth = register_test_user(
+        &server,
+        &format!("conv_dup_{}", timestamp),
+        &format!("conv_dup_{}@example.com", timestamp),
+        "SecurePass123!",
+        "Convert Dup User",
+    )
+    .await;
+
+    let source = create_account_with_currency(&server, &auth.token, "EUR Source", "EUR").await;
+    let dest = create_account_with_currency(&server, &auth.token, "EUR Dest", "EUR").await;
+    let third = create_account_with_currency(&server, &auth.token, "EUR Third", "EUR").await;
+
+    let txn = create_normal_transaction(&server, &auth.token, source.id, -100.0, json!({})).await;
+
+    // First conversion succeeds.
+    let ok = post_authenticated(
+        &server,
+        &format!("/api/v1/transactions/{}/convert-to-transfer", txn.id),
+        &auth.token,
+        &json!({ "account_id": dest.id }),
+    )
+    .await;
+    assert_status(&ok, 201);
+
+    // Second conversion of the same transaction is refused.
+    let again = post_authenticated(
+        &server,
+        &format!("/api/v1/transactions/{}/convert-to-transfer", txn.id),
+        &auth.token,
+        &json!({ "account_id": third.id }),
+    )
+    .await;
+    assert_status(&again, 422);
+}

--- a/frontend/src/components/transactions/ConvertToTransferModal.tsx
+++ b/frontend/src/components/transactions/ConvertToTransferModal.tsx
@@ -1,0 +1,223 @@
+import { useMemo, useState } from 'react';
+import { Box, Button, HStack, Input, Text, VStack } from '@chakra-ui/react';
+import {
+  DialogRoot,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogBody,
+  DialogFooter,
+  DialogCloseTrigger,
+  DialogBackdrop,
+} from '@chakra-ui/react';
+import { Field } from '@/components/ui/field';
+import { ErrorAlert } from '@/components/common';
+import { toaster } from '@/components/ui/toaster';
+import { useConvertToTransfer } from '@/hooks';
+import { AccountType } from '@/types';
+import type { Account, ConvertToTransferRequest, CurrencyCode } from '@/types';
+
+interface ConvertToTransferModalProps {
+  open: boolean;
+  onClose: () => void;
+  /** The transaction being converted. */
+  transactionId: string;
+  /** The transaction's own account id (excluded from the counterpart picker). */
+  transactionAccountId: string;
+  /** The transaction's amount as a string (sign drives direction messaging). */
+  transactionAmount: string;
+  /** Currency of the transaction's account (for cross-currency detection). */
+  transactionCurrency: CurrencyCode;
+  accounts: Account[];
+  onSuccess?: () => void;
+}
+
+const selectStyle = {
+  width: '100%',
+  padding: '8px',
+  borderRadius: '6px',
+  border: '1px solid #E2E8F0',
+};
+
+export const ConvertToTransferModal = ({
+  open,
+  onClose,
+  transactionId,
+  transactionAccountId,
+  transactionAmount,
+  transactionCurrency,
+  accounts,
+  onSuccess,
+}: ConvertToTransferModalProps) => {
+  const [counterpartId, setCounterpartId] = useState('');
+  const [counterpartAmount, setCounterpartAmount] = useState('');
+  const [exchangeRate, setExchangeRate] = useState('');
+
+  const convertMutation = useConvertToTransfer();
+
+  // Counterpart options: exclude debt accounts and the transaction's own account.
+  const counterpartOptions = useMemo(
+    () =>
+      accounts.filter(
+        (a) => a.account_type !== AccountType.DEBT && a.id !== transactionAccountId
+      ),
+    [accounts, transactionAccountId]
+  );
+
+  const counterpart = counterpartOptions.find((a) => a.id === counterpartId);
+  const isCrossCurrency = !!counterpart && counterpart.currency !== transactionCurrency;
+
+  // Direction messaging: a positive (credit) transaction means money came FROM
+  // the counterpart (it's the source); a negative (debit) means money went TO it.
+  const amountNum = Number(transactionAmount);
+  const directionHint =
+    amountNum > 0
+      ? 'This credit will be recorded as money transferred FROM the selected account.'
+      : 'This debit will be recorded as money transferred TO the selected account.';
+
+  const reset = () => {
+    setCounterpartId('');
+    setCounterpartAmount('');
+    setExchangeRate('');
+  };
+
+  const handleClose = () => {
+    reset();
+    onClose();
+  };
+
+  const handleSubmit = async () => {
+    if (!counterpartId) return;
+
+    const data: ConvertToTransferRequest = { account_id: counterpartId };
+    if (isCrossCurrency) {
+      if (counterpartAmount) {
+        data.counterpart_amount = Number(counterpartAmount);
+      } else if (exchangeRate) {
+        data.exchange_rate = Number(exchangeRate);
+      }
+    }
+
+    try {
+      await convertMutation.mutateAsync({ transactionId, data });
+      toaster.create({
+        title: 'Converted to transfer',
+        description: 'The transaction is now linked as a transfer.',
+        type: 'success',
+      });
+      reset();
+      onSuccess?.();
+      onClose();
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : 'Failed to convert transaction to transfer';
+      toaster.create({ title: 'Conversion failed', description: message, type: 'error' });
+    }
+  };
+
+  return (
+    <DialogRoot open={open} onOpenChange={(e) => !e.open && handleClose()} size="lg">
+      <DialogBackdrop />
+      <DialogContent
+        css={{
+          position: 'fixed',
+          top: '50%',
+          left: '50%',
+          transform: 'translate(-50%, -50%)',
+          zIndex: 9999,
+          maxHeight: '90vh',
+          overflow: 'auto',
+        }}
+      >
+        <DialogHeader>
+          <DialogTitle>Convert to Transfer</DialogTitle>
+          <DialogCloseTrigger />
+        </DialogHeader>
+
+        <DialogBody>
+          <VStack align="stretch" gap={4}>
+            {convertMutation.error && <ErrorAlert error={convertMutation.error} />}
+
+            <Text fontSize="sm" color="fg.muted">
+              {directionHint}
+            </Text>
+
+            <Field label="Counterpart Account" required>
+              <select
+                value={counterpartId}
+                onChange={(e) => setCounterpartId(e.target.value)}
+                style={selectStyle}
+              >
+                <option value="">Select account</option>
+                {counterpartOptions.map((account) => (
+                  <option key={account.id} value={account.id}>
+                    {account.name} ({account.currency})
+                  </option>
+                ))}
+              </select>
+            </Field>
+
+            {isCrossCurrency && (
+              <Box
+                p={4}
+                borderWidth="1px"
+                borderColor="border.muted"
+                borderRadius="md"
+                bg="bg.muted"
+              >
+                <Text fontSize="sm" fontWeight="semibold" mb={3}>
+                  Cross-currency conversion
+                </Text>
+                <Text fontSize="xs" color="fg.muted" mb={3}>
+                  The accounts use different currencies. Provide either the amount on the
+                  counterpart account or an exchange rate.
+                </Text>
+                <VStack align="stretch" gap={3}>
+                  <Field label={`Counterpart amount (${counterpart?.currency ?? ''})`}>
+                    <Input
+                      value={counterpartAmount}
+                      onChange={(e) => setCounterpartAmount(e.target.value)}
+                      type="number"
+                      step="0.01"
+                      min="0"
+                      placeholder="0.00"
+                    />
+                  </Field>
+                  <Field
+                    label="Exchange Rate"
+                    helperText={`1 ${transactionCurrency} = ? ${counterpart?.currency ?? ''}`}
+                  >
+                    <Input
+                      value={exchangeRate}
+                      onChange={(e) => setExchangeRate(e.target.value)}
+                      type="number"
+                      step="0.000001"
+                      min="0"
+                      placeholder="1.0000"
+                    />
+                  </Field>
+                </VStack>
+              </Box>
+            )}
+          </VStack>
+        </DialogBody>
+
+        <DialogFooter>
+          <HStack gap={2}>
+            <Button variant="outline" onClick={handleClose} disabled={convertMutation.isPending}>
+              Cancel
+            </Button>
+            <Button
+              colorPalette="blue"
+              onClick={() => void handleSubmit()}
+              disabled={!counterpartId}
+              loading={convertMutation.isPending}
+            >
+              Convert
+            </Button>
+          </HStack>
+        </DialogFooter>
+      </DialogContent>
+    </DialogRoot>
+  );
+};

--- a/frontend/src/components/transactions/detail/TransactionActions.tsx
+++ b/frontend/src/components/transactions/detail/TransactionActions.tsx
@@ -1,11 +1,12 @@
 import { Button, HStack } from '@chakra-ui/react';
-import { FiEdit2, FiTrash2 } from 'react-icons/fi';
+import { FiEdit2, FiRepeat, FiTrash2 } from 'react-icons/fi';
 import { HiOutlineDocumentDuplicate } from 'react-icons/hi';
 
 interface TransactionActionsProps {
   onEdit: () => void;
   onDelete: () => void;
   onDuplicate?: () => void;
+  onConvertToTransfer?: () => void;
   isDeleting: boolean;
 }
 
@@ -13,6 +14,7 @@ export const TransactionActions = ({
   onEdit,
   onDelete,
   onDuplicate,
+  onConvertToTransfer,
   isDeleting,
 }: TransactionActionsProps) => {
   return (
@@ -28,6 +30,14 @@ export const TransactionActions = ({
           <HStack gap={2}>
             <HiOutlineDocumentDuplicate />
             <span>Duplicate</span>
+          </HStack>
+        </Button>
+      )}
+      {onConvertToTransfer && (
+        <Button variant="outline" colorScheme="purple" onClick={onConvertToTransfer}>
+          <HStack gap={2}>
+            <FiRepeat />
+            <span>Convert to transfer</span>
           </HStack>
         </Button>
       )}

--- a/frontend/src/components/transactions/index.ts
+++ b/frontend/src/components/transactions/index.ts
@@ -7,6 +7,7 @@ export type { TransactionFilterValues } from './TransactionFilters';
 export { TransactionFilterDrawer } from './TransactionFilterDrawer';
 export { TransactionFormModal } from './TransactionFormModal';
 export { TransferFormModal } from './TransferFormModal';
+export { ConvertToTransferModal } from './ConvertToTransferModal';
 export { SplitPaymentForm } from './SplitPaymentForm';
 export { DebtExpenseParticipantsForm } from './DebtExpenseParticipantsForm';
 export { SplitSyncStatus } from './SplitSyncStatus';

--- a/frontend/src/hooks/api/index.ts
+++ b/frontend/src/hooks/api/index.ts
@@ -4,6 +4,7 @@ export { default as useTransaction } from './useTransaction';
 export { default as useCreateTransaction } from './useCreateTransaction';
 export { default as useCreateDebtTransaction } from './useCreateDebtTransaction';
 export { default as useCreateTransfer } from './useCreateTransfer';
+export { default as useConvertToTransfer } from './useConvertToTransfer';
 export { default as useUpdateTransaction } from './useUpdateTransaction';
 export { default as useDeleteTransaction } from './useDeleteTransaction';
 export { default as useTrashTransactions } from './useTrashTransactions';

--- a/frontend/src/hooks/api/useConvertToTransfer.ts
+++ b/frontend/src/hooks/api/useConvertToTransfer.ts
@@ -1,0 +1,31 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { convertToTransfer } from '@/services/transferService';
+import type { ConvertToTransferRequest } from '@/types';
+
+interface ConvertToTransferVars {
+  transactionId: string;
+  data: ConvertToTransferRequest;
+}
+
+/**
+ * Convert an existing transaction into a transfer.
+ * Invalidates transactions, accounts, dashboard, and budgets queries on success
+ * (a conversion creates a linked leg and shifts account balances).
+ *
+ * @returns React Query mutation for converting a transaction to a transfer
+ */
+export default function useConvertToTransfer() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ transactionId, data }: ConvertToTransferVars) =>
+      convertToTransfer(transactionId, data),
+    onSuccess: (_result, { transactionId }) => {
+      void queryClient.invalidateQueries({ queryKey: ['transactions'] });
+      void queryClient.invalidateQueries({ queryKey: ['transaction', transactionId] });
+      void queryClient.invalidateQueries({ queryKey: ['accounts'] });
+      void queryClient.invalidateQueries({ queryKey: ['dashboard'] });
+      void queryClient.invalidateQueries({ queryKey: ['budgets'] });
+    },
+  });
+}

--- a/frontend/src/pages/TransactionDetail.tsx
+++ b/frontend/src/pages/TransactionDetail.tsx
@@ -7,7 +7,7 @@ import {
   TransactionActions,
   SplitMismatchModal,
 } from '@/components/transactions/detail';
-import { TransactionFormModal } from '@/components/transactions';
+import { TransactionFormModal, ConvertToTransferModal } from '@/components/transactions';
 import {
   useUpdateTransaction,
   useDeleteTransaction,
@@ -102,6 +102,11 @@ export const TransactionDetailPage = () => {
     onOpen: onDuplicateOpen,
     onClose: onDuplicateClose,
   } = useDisclosure();
+  const {
+    open: isConvertOpen,
+    onOpen: onConvertOpen,
+    onClose: onConvertClose,
+  } = useDisclosure();
 
   const updateMutation = useUpdateTransaction();
   const deleteMutation = useDeleteTransaction();
@@ -192,6 +197,10 @@ export const TransactionDetailPage = () => {
   // Only show sync button if transaction has splits
   const hasSplits = transaction.splits && transaction.splits.length > 0;
 
+  // "Convert to transfer" is only offered for a plain transaction: not one that
+  // has splits, and not one that is already part of a transfer.
+  const canConvertToTransfer = !hasSplits && !transaction.transfer_info;
+
   return (
     <Box maxW="2xl" mx="auto">
       <PageHeader
@@ -201,6 +210,7 @@ export const TransactionDetailPage = () => {
             onEdit={handleEdit}
             onDelete={handleDelete}
             onDuplicate={!transaction.transfer_info ? handleDuplicate : undefined}
+            onConvertToTransfer={canConvertToTransfer ? onConvertOpen : undefined}
             isDeleting={deleteMutation.isPending}
           />
         }
@@ -267,6 +277,17 @@ export const TransactionDetailPage = () => {
         people={peopleData || []}
         onSubmit={handleDuplicateSubmit}
         onSubmitDebt={handleDuplicateDebtSubmit}
+      />
+
+      {/* Convert to Transfer Modal */}
+      <ConvertToTransferModal
+        open={isConvertOpen}
+        onClose={onConvertClose}
+        transactionId={transaction.id}
+        transactionAccountId={transaction.account.id}
+        transactionAmount={transaction.amount}
+        transactionCurrency={transaction.account.currency}
+        accounts={accountsData || []}
       />
 
       {/* Delete Confirmation */}

--- a/frontend/src/services/transferService.ts
+++ b/frontend/src/services/transferService.ts
@@ -1,10 +1,29 @@
 import apiClient from '@/lib/axios';
-import type { CreateTransferRequest, TransferResponse } from '@/types';
+import type {
+  ConvertToTransferRequest,
+  CreateTransferRequest,
+  TransferResponse,
+} from '@/types';
 
 /**
  * Create a transfer between two accounts
  */
 export async function createTransfer(data: CreateTransferRequest): Promise<TransferResponse> {
   const response = await apiClient.post<TransferResponse>('/transfers', data);
+  return response.data;
+}
+
+/**
+ * Convert an existing transaction into a transfer by linking it with a new
+ * opposite leg on the chosen counterpart account.
+ */
+export async function convertToTransfer(
+  transactionId: string,
+  data: ConvertToTransferRequest
+): Promise<TransferResponse> {
+  const response = await apiClient.post<TransferResponse>(
+    `/transactions/${transactionId}/convert-to-transfer`,
+    data
+  );
   return response.data;
 }

--- a/frontend/src/types/models.ts
+++ b/frontend/src/types/models.ts
@@ -176,6 +176,16 @@ export interface TransferResponse {
   created_at: string;
 }
 
+// Request to convert an existing transaction into a transfer.
+// Direction is inferred from the transaction's amount sign, so it is never sent.
+export interface ConvertToTransferRequest {
+  account_id: string;
+  // Cross-currency only: the absolute amount on the counterpart account's leg.
+  counterpart_amount?: number;
+  // Alternative to counterpart_amount for cross-currency conversions.
+  exchange_rate?: number;
+}
+
 export interface CreateTransactionRequest {
   title: string;
   amount: number; // Backend expects f64 (number)


### PR DESCRIPTION
## Summary

Adds an action to convert an existing normal transaction into a proper two-leg linked transfer, indistinguishable from a natively-created one. You pick the counterpart account; MOC creates the opposite leg and links both under one `transfers` row.

New endpoint: `POST /api/v1/transactions/:id/convert-to-transfer`

## Behaviour (per Abhijeet's locked spec)

- **Retro-join, not delete/recreate** — the original transaction is left untouched and becomes one leg; only the opposite leg + the `transfers` row are inserted. No churn of the original's id/links.
- **Direction inferred from sign** — original **negative** (debit) → counterpart is the destination (new leg positive); original **positive** (credit) → counterpart is the source (new leg negative). Never stated by the caller.
- **Category preserved** — the original category is copied to the new leg, never overwritten with a "Transfer" category (transfer-ness is derived from the `transfers` table, not category, so this is safe).
- **Splits hard-refused** — converting a transaction that has splits returns a validation error (422) with a clear message; the UI should also hide the action when splits exist (frontend already has `splits` on the transaction object).
- **Guards:** refuses if the transaction is already part of a transfer, if the amount is zero, if the counterpart equals the original's account, if soft-deleted, and enforces account ownership.
- **Atomic:** the new leg + `transfers` row are inserted inside a single `conn.transaction()`, so a mid-way failure rolls back entirely — no half-converted state.
- **Cross-currency** supported via optional `counterpart_amount` or `exchange_rate` (same as native transfers).

## API

`POST /api/v1/transactions/:id/convert-to-transfer` (auth: JWT or API key with Transactions/Write scope)

```jsonc
{
  "account_id": "<counterpart account uuid>",   // required
  "counterpart_amount": 900.0,                  // optional, cross-currency only
  "exchange_rate": 0.9                           // optional, alternative to counterpart_amount
}
```
Returns the same `TransferResponse` shape as `POST /transfers` (from/to legs + exchange_rate).

## Changes
- `models/transfer.rs`: `ConvertToTransferRequest` DTO.
- `repositories/transfer.rs`: `join_transaction_into_transfer_atomic` (inserts new leg + transfers row in one txn).
- `services/transfer_service.rs`: `convert_transaction_to_transfer` (all guards + direction/amount/currency resolution).
- `handlers/transfers.rs`: `convert_to_transfer` handler.
- `api/routes.rs`: new route under Transactions/Write scope.

## Testing
- `cargo build` + `cargo test --no-run` pass (only pre-existing warnings).
- 5 new integration tests, all passing against a Postgres 16 instance: debit→destination, credit→source, category preserved on both legs, splits refused (422), and double-convert refused (422).

## Notes
Backend only — no migration (transfer linkage already lives in the `transfers` table; nothing added to `transactions`). A UI action (hidden when the txn has splits/is already a transfer) is the natural frontend follow-up.