### PR TITLE
feat: beta preview image workflow and demo seed

### DIFF
--- a/.github/workflows/beta-image.yml
+++ b/.github/workflows/beta-image.yml
@@ -1,0 +1,139 @@
+name: Build Beta Preview Image
+
+# Builds a chosen branch and publishes it under the moving `:beta` tag (plus an
+# immutable `:beta-<shortsha>` tag for traceability) so the beta preview slot can
+# serve any PR branch. This NEVER touches `:latest` or any semver/prod tag, and
+# it does NOT trigger the production deploy webhook — production is unaffected.
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: "Branch (or ref) to build for the beta slot, e.g. feat/convert-transaction-to-transfer"
+        required: true
+        type: string
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  # ============================================================================
+  # Build platform-specific images in parallel (native runners = no QEMU)
+  # ============================================================================
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout the requested branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.branch }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      # Build and push by digest (no tag yet — tags applied in the merge job)
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: ${{ matrix.platform }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=beta-${{ matrix.platform }}
+          cache-to: type=gha,mode=max,scope=beta-${{ matrix.platform }}
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
+
+      - name: Save digest artifact
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: beta-digests-${{ matrix.runner }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  # ============================================================================
+  # Merge platform images into a multi-arch manifest under the beta tags
+  # ============================================================================
+  merge:
+    runs-on: ubuntu-latest
+    needs: build
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout the requested branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.branch }}
+
+      - name: Resolve short commit SHA
+        id: sha
+        run: echo "short=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: beta-digests-*
+          merge-multiple: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Create the multi-arch manifest and apply ONLY the beta tags.
+      # `:beta` is the moving "what's live in the beta slot now" tag;
+      # `:beta-<shortsha>` is immutable for traceability.
+      # `:latest` and semver tags are deliberately NOT written here.
+      - name: Create manifest list and push beta tags
+        working-directory: /tmp/digests
+        run: |
+          docker buildx imagetools create \
+            -t ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:beta \
+            -t ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:beta-${{ steps.sha.outputs.short }} \
+            $(printf '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@sha256:%s ' *)
+
+      - name: Report published tags
+        run: |
+          echo "Published beta image for branch '${{ inputs.branch }}' (commit ${{ steps.sha.outputs.short }})"
+          echo "  ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:beta"
+          echo "  ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:beta-${{ steps.sha.outputs.short }}"

--- a/scripts/deploy-beta.sh
+++ b/scripts/deploy-beta.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+#
+# One-command "preview PR #NN on the beta slot" helper (app-repo side).
+#
+# Triggers the beta-image workflow for a given branch (or PR number), waits for
+# it to publish the `:beta` image, and prints the redeploy reminder. The actual
+# container recreate happens on the home server (deploy repo's beta stack) and
+# is intentionally NOT done here — this script only owns the app-repo half
+# (build + push the beta image). It never touches production tags or the prod
+# deploy webhook.
+#
+# Usage:
+#   ./scripts/deploy-beta.sh <branch>
+#   ./scripts/deploy-beta.sh 73          # a PR number — resolves to its branch
+#
+# Requires: gh (authenticated).
+
+set -euo pipefail
+
+command -v gh >/dev/null 2>&1 || { echo "Missing dependency: gh" >&2; exit 1; }
+
+REF="${1:-}"
+if [ -z "$REF" ]; then
+  echo "Usage: $0 <branch|pr-number>" >&2
+  exit 1
+fi
+
+# If REF is all digits, treat it as a PR number and resolve to its head branch.
+if [[ "$REF" =~ ^[0-9]+$ ]]; then
+  echo "Resolving PR #${REF} to its branch..."
+  BRANCH=$(gh pr view "$REF" --json headRefName --jq '.headRefName')
+  echo "PR #${REF} → ${BRANCH}"
+else
+  BRANCH="$REF"
+fi
+
+echo "Triggering beta-image build for branch '${BRANCH}'..."
+gh workflow run beta-image.yml -f branch="${BRANCH}"
+
+echo "Waiting a moment for the run to register..."
+sleep 6
+
+# Grab the most recent beta-image run id and watch it.
+RUN_ID=$(gh run list --workflow=beta-image.yml --limit 1 --json databaseId --jq '.[0].databaseId')
+echo "Watching run ${RUN_ID}..."
+gh run watch "${RUN_ID}" --exit-status
+
+echo ""
+echo "✅ Beta image published: ghcr.io/<owner>/master-of-coin:beta (branch ${BRANCH})"
+echo ""
+echo "Next step (home server): recreate the beta stack so it pulls the new :beta image, e.g.:"
+echo "    docker compose -p moc-beta pull && docker compose -p moc-beta up -d"
+echo "(or redeploy the moc-beta stack in Portainer). The beta stack uses its own"
+echo "throwaway seeded database — never production data."

--- a/scripts/seed-beta-demo.sh
+++ b/scripts/seed-beta-demo.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+#
+# Seed the BETA preview instance with throwaway demo data.
+#
+# This talks to a running MOC beta instance over its HTTP API (register →
+# create accounts/categories/budgets/transactions) using the real code paths,
+# so the seed can never drift from the schema and needs no hand-crafted hashes.
+#
+# SAFETY: this is for the BETA slot ONLY. It creates a fresh demo user with
+# fake data. Never point BETA_URL at production — the beta stack uses its own
+# throwaway database (see the deploy repo's docker-compose.beta.yml).
+#
+# Usage:
+#   BETA_URL=https://moc.beta.abhijeetreddy.in ./scripts/seed-beta-demo.sh
+# Optional overrides:
+#   DEMO_EMAIL, DEMO_USERNAME, DEMO_PASSWORD, DEMO_NAME
+#
+# The script is idempotent-ish: if the demo user already exists, registration
+# fails and it logs in instead, then skips creating duplicate accounts by name.
+
+set -euo pipefail
+
+BETA_URL="${BETA_URL:-http://localhost:13253}"
+API="${BETA_URL%/}/api/v1"
+DEMO_EMAIL="${DEMO_EMAIL:-demo@moc.local}"
+DEMO_USERNAME="${DEMO_USERNAME:-demo}"
+DEMO_PASSWORD="${DEMO_PASSWORD:-demo@password}"
+DEMO_NAME="${DEMO_NAME:-Demo User}"
+
+need() { command -v "$1" >/dev/null 2>&1 || { echo "Missing dependency: $1" >&2; exit 1; }; }
+need curl
+need jq
+
+echo "Seeding beta demo data at ${API}"
+
+# --- Guard: refuse anything that looks like production ------------------------
+case "${BETA_URL}" in
+  *beta*|*localhost*|*127.0.0.1*) : ;;
+  *)
+    echo "Refusing to seed: BETA_URL '${BETA_URL}' does not look like a beta/local host." >&2
+    echo "This script must never run against production." >&2
+    exit 1
+    ;;
+esac
+
+# --- Register (or log in if the demo user already exists) ---------------------
+register_body=$(jq -n \
+  --arg u "$DEMO_USERNAME" --arg e "$DEMO_EMAIL" --arg p "$DEMO_PASSWORD" --arg n "$DEMO_NAME" \
+  '{username:$u, email:$e, password:$p, name:$n}')
+
+reg_resp=$(curl -s -o /tmp/seed_reg.json -w "%{http_code}" \
+  -X POST "${API}/auth/register" -H 'Content-Type: application/json' -d "$register_body")
+
+if [ "$reg_resp" = "201" ] || [ "$reg_resp" = "200" ]; then
+  TOKEN=$(jq -r '.token' /tmp/seed_reg.json)
+  echo "Registered demo user."
+else
+  echo "Register returned HTTP ${reg_resp}; attempting login (user may already exist)."
+  login_body=$(jq -n --arg e "$DEMO_EMAIL" --arg p "$DEMO_PASSWORD" '{email:$e, password:$p}')
+  curl -s -o /tmp/seed_login.json -X POST "${API}/auth/login" \
+    -H 'Content-Type: application/json' -d "$login_body"
+  TOKEN=$(jq -r '.token' /tmp/seed_login.json)
+fi
+
+if [ -z "${TOKEN:-}" ] || [ "$TOKEN" = "null" ]; then
+  echo "Failed to obtain auth token; aborting." >&2
+  exit 1
+fi
+AUTH=(-H "Authorization: Bearer ${TOKEN}")
+
+# --- Helpers ------------------------------------------------------------------
+post() { curl -s "${AUTH[@]}" -H 'Content-Type: application/json' -X POST "${API}$1" -d "$2"; }
+
+existing_accounts=$(curl -s "${AUTH[@]}" "${API}/accounts")
+account_exists() { echo "$existing_accounts" | jq -e --arg n "$1" 'any(.[]; .name == $n)' >/dev/null 2>&1; }
+
+create_account() { # name type currency initial_balance
+  if account_exists "$1"; then echo "  account '$1' exists, skipping"; return; fi
+  local body
+  body=$(jq -n --arg n "$1" --arg t "$2" --arg c "$3" --argjson b "$4" \
+    '{name:$n, account_type:$t, currency:$c, initial_balance:$b}')
+  post "/accounts" "$body" | jq -r '"  account: " + .name + " (" + .id + ")"'
+}
+
+create_category() { # name
+  post "/categories" "$(jq -n --arg n "$1" '{name:$n}')" | jq -r '"  category: " + .name + " (" + .id + ")"'
+}
+
+# --- Seed accounts ------------------------------------------------------------
+echo "Creating demo accounts..."
+create_account "Demo Checking" "CHECKING" "EUR" 2500
+create_account "Demo Savings" "SAVINGS" "EUR" 8000
+create_account "Demo Brokerage" "INVESTMENT" "EUR" 15000
+create_account "Demo Credit Card" "CREDIT_CARD" "EUR" -420
+
+# Re-fetch accounts to get ids for transactions
+accounts=$(curl -s "${AUTH[@]}" "${API}/accounts")
+checking_id=$(echo "$accounts" | jq -r '.[] | select(.name=="Demo Checking") | .id')
+
+# --- Seed categories ----------------------------------------------------------
+echo "Creating demo categories..."
+create_category "Groceries" >/dev/null || true
+create_category "Salary" >/dev/null || true
+create_category "Dining" >/dev/null || true
+create_category "Transport" >/dev/null || true
+cats=$(curl -s "${AUTH[@]}" "${API}/categories")
+groceries_id=$(echo "$cats" | jq -r '.[] | select(.name=="Groceries") | .id')
+salary_id=$(echo "$cats" | jq -r '.[] | select(.name=="Salary") | .id')
+
+# --- Seed transactions --------------------------------------------------------
+echo "Creating demo transactions..."
+mk_txn() { # account_id title amount category_id
+  local body
+  body=$(jq -n --arg a "$1" --arg t "$2" --argjson amt "$3" --arg c "$4" --arg d "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+    '{account_id:$a, title:$t, amount:$amt, date:$d} + (if $c != "" then {category_id:$c} else {} end)')
+  post "/transactions" "$body" >/dev/null
+}
+
+if [ -n "$checking_id" ]; then
+  mk_txn "$checking_id" "Monthly salary" 3200 "$salary_id"
+  mk_txn "$checking_id" "Supermarket" -76.40 "$groceries_id"
+  mk_txn "$checking_id" "Coffee" -4.20 ""
+  mk_txn "$checking_id" "Train ticket" -12.00 ""
+fi
+
+echo "Beta demo seed complete."
+echo "Login: ${DEMO_EMAIL} / ${DEMO_PASSWORD}"

--- a/scripts/seed-beta-demo.sh
+++ b/scripts/seed-beta-demo.sh
@@ -15,8 +15,10 @@
 # Optional overrides:
 #   DEMO_EMAIL, DEMO_USERNAME, DEMO_PASSWORD, DEMO_NAME
 #
-# The script is idempotent-ish: if the demo user already exists, registration
-# fails and it logs in instead, then skips creating duplicate accounts by name.
+# This is a MANUAL, run-on-demand script — it is NOT a container boot hook, so
+# it never runs on container start and a beta restart mid-test cannot wipe or
+# re-seed anything. It is also self-guarding: if the demo user already has any
+# accounts, it exits immediately without touching existing data. Safe to re-run.
 
 set -euo pipefail
 
@@ -72,6 +74,18 @@ AUTH=(-H "Authorization: Bearer ${TOKEN}")
 post() { curl -s "${AUTH[@]}" -H 'Content-Type: application/json' -X POST "${API}$1" -d "$2"; }
 
 existing_accounts=$(curl -s "${AUTH[@]}" "${API}/accounts")
+
+# --- Only seed a fresh instance ----------------------------------------------
+# If the demo user already has any accounts, assume seeding has run and STOP.
+# This makes the script safe to re-run and, crucially, means it never wipes or
+# re-adds data on top of state built up while exercising the app (e.g. a beta
+# container restart mid-test must not disturb what the tester created).
+if echo "$existing_accounts" | jq -e 'length > 0' >/dev/null 2>&1; then
+  echo "Demo user already has accounts — instance is already seeded. Nothing to do."
+  echo "Login: ${DEMO_EMAIL} / ${DEMO_PASSWORD}"
+  exit 0
+fi
+
 account_exists() { echo "$existing_accounts" | jq -e --arg n "$1" 'any(.[]; .name == $n)' >/dev/null 2>&1; }
 
 create_account() { # name type currency initial_balance


### PR DESCRIPTION
App-repo half of the beta preview slot (design: `.agents/features/beta-preview-slot/design.md`, PR #72). Purpose: stand up a beta slot to test PR #73 (convert-to-transfer) before merging.

**This is the APP-REPO side only.** The deploy side (the `docker-compose.beta.yml` stack) and the Cloudflare Tunnel ingress for `moc.beta.abhijeetreddy.in` live in the `valyria-home-server` repo and are handled separately (branch → PR → merge; Cloudflare is a manual API step by home-server-agent). Nothing here touches production.

## What's included

- **`.github/workflows/beta-image.yml`** — `workflow_dispatch(branch)` workflow that builds the chosen branch (same Dockerfile / multi-arch build as `docker-publish.yml`) and publishes it to GHCR under:
  - `:beta` — moving tag, "what's live in the beta slot now"
  - `:beta-<shortsha>` — immutable, for traceability

  It **deliberately does not** write `:latest` or any semver tag, and does **not** trigger the production deploy webhook. Prod is untouched.
- **`scripts/seed-beta-demo.sh`** — seeds the beta instance with throwaway demo data over the HTTP API (register a demo user → create demo accounts/categories/transactions via the real code paths, so no schema drift / no hand-crafted password hashes). Has a guard that refuses to run unless `BETA_URL` looks like a beta/local host — it must never point at production.
- **`scripts/deploy-beta.sh`** — one-command helper: `./scripts/deploy-beta.sh 73` (PR number or branch) triggers the beta-image workflow, watches it, and prints the home-server recreate reminder.

## Data safety

The beta stack (deploy repo) uses its **own throwaway seeded database with its own volume** — never a copy of real MOC data and never pointed at the production database. Combined with a distinct `ENCRYPTION_KEY` + TrueLayer sandbox in the beta env, beta cannot touch real accounts or providers. This is what makes it safe to test #73's convert-to-transfer (a destructive-ish op) without risk.

## Usage once merged + beta stack is up

1. `gh workflow run beta-image.yml -f branch=feat/convert-transaction-to-transfer` (or `./scripts/deploy-beta.sh 73`)
2. Home server recreates the `moc-beta` stack to pull the new `:beta` image (migrations run at boot).
3. `BETA_URL=https://moc.beta.abhijeetreddy.in ./scripts/seed-beta-demo.sh` to populate demo data.
4. Test convert-to-transfer at `moc.beta.abhijeetreddy.in`.

## Validation
- `beta-image.yml` validated as well-formed YAML; both scripts pass `bash -n`.

## Demo login & seed behaviour (note for testers)
- Demo login: **`demo@moc.local` / `demo@password`** (created by the seed).
- The seed is **first-time-only**: `seed-beta-demo.sh` is a manual script (never runs on container boot) and exits immediately if the demo user already has accounts. Re-running it later will NOT reset data — nothing changes by design. For a clean slate, reset the beta DB (`docker compose -p moc-beta down -v && up -d`), then re-run the seed.
