### PR TITLE
fix: move transaction actions into a kebab overflow menu

### DIFF
--- a/frontend/src/components/transactions/detail/TransactionActions.tsx
+++ b/frontend/src/components/transactions/detail/TransactionActions.tsx
@@ -1,5 +1,5 @@
-import { Button, HStack } from '@chakra-ui/react';
-import { FiEdit2, FiRepeat, FiTrash2 } from 'react-icons/fi';
+import { Button, HStack, IconButton, Menu, Portal } from '@chakra-ui/react';
+import { FiEdit2, FiMoreVertical, FiRepeat, FiTrash2 } from 'react-icons/fi';
 import { HiOutlineDocumentDuplicate } from 'react-icons/hi';
 
 interface TransactionActionsProps {
@@ -10,6 +10,20 @@ interface TransactionActionsProps {
   isDeleting: boolean;
 }
 
+/**
+ * Transaction detail toolbar.
+ *
+ * Layout: a single Edit button plus a kebab (three-dot) overflow menu holding
+ * the remaining actions. Keeping only two elements here means the breadcrumb
+ * always has room and can never be crushed at narrow widths.
+ *
+ * Menu order: Convert to transfer (newest, most deliberate) → Duplicate →
+ * Delete last, visually separated and styled destructive so it isn't one
+ * mis-click from the others. `onDuplicate` / `onConvertToTransfer` are optional:
+ * the caller omits them when the action doesn't apply (e.g. convert-to-transfer
+ * is not offered for transactions with splits or that are already transfers),
+ * so those items simply don't render.
+ */
 export const TransactionActions = ({
   onEdit,
   onDelete,
@@ -25,28 +39,48 @@ export const TransactionActions = ({
           <span>Edit</span>
         </HStack>
       </Button>
-      {onDuplicate && (
-        <Button variant="outline" colorScheme="teal" onClick={onDuplicate}>
-          <HStack gap={2}>
-            <HiOutlineDocumentDuplicate />
-            <span>Duplicate</span>
-          </HStack>
-        </Button>
-      )}
-      {onConvertToTransfer && (
-        <Button variant="outline" colorScheme="purple" onClick={onConvertToTransfer}>
-          <HStack gap={2}>
-            <FiRepeat />
-            <span>Convert to transfer</span>
-          </HStack>
-        </Button>
-      )}
-      <Button variant="outline" colorScheme="red" onClick={onDelete} disabled={isDeleting}>
-        <HStack gap={2}>
-          <FiTrash2 />
-          <span>Delete</span>
-        </HStack>
-      </Button>
+
+      <Menu.Root>
+        <Menu.Trigger asChild>
+          <IconButton aria-label="More actions" variant="outline">
+            <FiMoreVertical />
+          </IconButton>
+        </Menu.Trigger>
+        <Portal>
+          <Menu.Positioner>
+            <Menu.Content>
+              {onConvertToTransfer && (
+                <Menu.Item value="convert-to-transfer" onClick={onConvertToTransfer}>
+                  <HStack gap={2}>
+                    <FiRepeat />
+                    <span>Convert to transfer</span>
+                  </HStack>
+                </Menu.Item>
+              )}
+              {onDuplicate && (
+                <Menu.Item value="duplicate" onClick={onDuplicate}>
+                  <HStack gap={2}>
+                    <HiOutlineDocumentDuplicate />
+                    <span>Duplicate</span>
+                  </HStack>
+                </Menu.Item>
+              )}
+              <Menu.Separator />
+              <Menu.Item
+                value="delete"
+                color="red.500"
+                disabled={isDeleting}
+                onClick={onDelete}
+              >
+                <HStack gap={2}>
+                  <FiTrash2 />
+                  <span>Delete</span>
+                </HStack>
+              </Menu.Item>
+            </Menu.Content>
+          </Menu.Positioner>
+        </Portal>
+      </Menu.Root>
     </HStack>
   );
 };


### PR DESCRIPTION
## Problem

On the transaction **detail** page the breadcrumb and four buttons (Edit, Duplicate, Convert to transfer, Delete) shared one flex row. At ~790px the buttons refused to shrink and the breadcrumb collapsed to a ~30px column wrapping one or two characters per line. Adding "Convert to transfer" (the widest button) in #73 tipped it over. The CSS is fine — this is purely a flex-layout crowding problem.

## Fix (Idea 4)

The toolbar now shows only **Edit** + a **kebab (⋮) overflow menu**. With just two elements, the breadcrumb effectively gets the row to itself and can't be crushed at any width — that's the actual fix, not truncation or icon-only buttons.

Overflow menu order:
1. **Convert to transfer** (newest, most deliberate action)
2. **Duplicate**
3. *(divider)* **Delete** — last, visually separated, styled destructive (red), so a live financial record isn't one mis-click from the others.

## Preserved behaviour

- **Convert to transfer is still gated**: hidden for transactions with splits and for transactions that are already transfers. The gating lives at the call site (`TransactionDetail.tsx`: `canConvertToTransfer = !hasSplits && !transaction.transfer_info`) and is unchanged — the menu item only renders when `onConvertToTransfer` is passed, so nothing regresses.
- Duplicate remains hidden for transfers (unchanged).

## Implementation

- Uses the codebase's existing Chakra v3 `Menu.*` pattern (same as `BudgetFormModal`), rendered in a `Portal`. Keyboard accessible via Chakra's menu primitives.
- Only `TransactionActions.tsx` changed; the prop contract is unchanged, so the call site needs no edits.

## Not included (optional extras, pending Abhijeet's word)

Making Edit a primary/filled button, and the Details-card tweaks (drop redundant Currency row, demote "Created" to grey metadata) — deliberately left out unless requested.

## Validation

`tsc -b` clean and ESLint clean on the changed file.