### PR TITLE
feat: exclude categories from spending analysis

### DIFF
--- a/backend/migrations/2026-08-08-114241-0000_add_excluded_from_analysis_to_categories/down.sql
+++ b/backend/migrations/2026-08-08-114241-0000_add_excluded_from_analysis_to_categories/down.sql
@@ -1,0 +1,2 @@
+DROP INDEX IF EXISTS idx_categories_excluded_from_analysis;
+ALTER TABLE categories DROP COLUMN IF EXISTS is_excluded_from_analysis;

--- a/backend/migrations/2026-08-08-114241-0000_add_excluded_from_analysis_to_categories/up.sql
+++ b/backend/migrations/2026-08-08-114241-0000_add_excluded_from_analysis_to_categories/up.sql
@@ -1,0 +1,9 @@
+-- Mark categories that should be excluded from spending analysis
+-- (breakdown, budgeting, etc.). Excluded categories remain fully usable
+-- in the ledger and assignable to transactions; only aggregation ignores them.
+ALTER TABLE categories
+    ADD COLUMN is_excluded_from_analysis BOOLEAN NOT NULL DEFAULT FALSE;
+
+CREATE INDEX idx_categories_excluded_from_analysis
+    ON categories(is_excluded_from_analysis)
+    WHERE is_excluded_from_analysis = TRUE;

--- a/backend/src/handlers/categories.rs
+++ b/backend/src/handlers/categories.rs
@@ -88,6 +88,7 @@ pub async fn update(
         color: request.color,
         icon: request.icon,
         parent_id: None,
+        is_excluded_from_analysis: request.is_excluded_from_analysis,
     };
 
     let updated_category = repositories::category::update_category(&state.db, id, updates).await?;

--- a/backend/src/models/category.rs
+++ b/backend/src/models/category.rs
@@ -17,6 +17,7 @@ pub struct Category {
     pub parent_id: Option<Uuid>,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
+    pub is_excluded_from_analysis: bool,
 }
 
 #[derive(Debug, Insertable)]
@@ -43,6 +44,7 @@ pub struct UpdateCategory {
     pub icon: Option<String>,
     pub color: Option<String>,
     pub parent_id: Option<Uuid>,
+    pub is_excluded_from_analysis: Option<bool>,
 }
 
 // Request DTOs
@@ -65,6 +67,7 @@ pub struct UpdateCategoryRequest {
     pub icon: Option<String>,
     #[validate(length(max = 20))]
     pub color: Option<String>,
+    pub is_excluded_from_analysis: Option<bool>,
 }
 
 // Response DTOs
@@ -75,6 +78,7 @@ pub struct CategoryResponse {
     pub parent_id: Option<Uuid>,
     pub icon: Option<String>,
     pub color: Option<String>,
+    pub is_excluded_from_analysis: bool,
 }
 
 impl From<Category> for CategoryResponse {
@@ -85,6 +89,7 @@ impl From<Category> for CategoryResponse {
             parent_id: category.parent_id,
             icon: category.icon,
             color: category.color,
+            is_excluded_from_analysis: category.is_excluded_from_analysis,
         }
     }
 }

--- a/backend/src/repositories/budget.rs
+++ b/backend/src/repositories/budget.rs
@@ -1,7 +1,7 @@
 use bigdecimal::BigDecimal;
 use chrono::{DateTime, NaiveDate, Utc};
 use diesel::prelude::*;
-use diesel::sql_types::{Nullable, Numeric, Timestamptz, Uuid as DieselUuid};
+use diesel::sql_types::{Array, Nullable, Numeric, Timestamptz, Uuid as DieselUuid};
 use uuid::Uuid;
 
 use crate::{
@@ -284,6 +284,7 @@ pub async fn calculate_spending_by_currency(
     account_id: Option<Uuid>,
     start_date: Option<DateTime<Utc>>,
     end_date: Option<DateTime<Utc>>,
+    exclude_category_ids: Vec<Uuid>,
 ) -> Result<Vec<CurrencySpending>, ApiError> {
     let mut conn = pool.get().map_err(|e| {
         tracing::error!("Failed to get DB connection: {}", e);
@@ -291,6 +292,10 @@ pub async fn calculate_spending_by_currency(
     })?;
 
     tokio::task::spawn_blocking(move || {
+        // Categories excluded from analysis are dropped only for overall
+        // (no-category) budgets: a budget explicitly scoped to a category is
+        // honoured even if that category is excluded elsewhere. The clause
+        // never affects NULL-category (uncategorised) transactions.
         diesel::sql_query(
             "SELECT \
                 a.currency, \
@@ -310,6 +315,8 @@ pub async fn calculate_spending_by_currency(
               AND ($3::timestamptz IS NULL OR t.date >= $3) \
               AND ($4::timestamptz IS NULL OR t.date <= $4) \
               AND ($5::uuid IS NULL OR t.account_id = $5) \
+              AND ($2::uuid IS NOT NULL OR t.category_id IS NULL \
+                   OR t.category_id <> ALL($6)) \
             GROUP BY a.currency",
         )
         .bind::<DieselUuid, _>(user_id)
@@ -317,6 +324,7 @@ pub async fn calculate_spending_by_currency(
         .bind::<Nullable<Timestamptz>, _>(start_date)
         .bind::<Nullable<Timestamptz>, _>(end_date)
         .bind::<Nullable<DieselUuid>, _>(account_id)
+        .bind::<Array<DieselUuid>, _>(exclude_category_ids)
         .load::<CurrencySpending>(&mut conn)
         .map_err(|e| {
             tracing::error!(

--- a/backend/src/repositories/category.rs
+++ b/backend/src/repositories/category.rs
@@ -131,6 +131,19 @@ pub async fn update_category(
                     ApiError::from(e)
                 })?;
         }
+        if let Some(is_excluded_from_analysis) = updates.is_excluded_from_analysis {
+            diesel::update(categories::table.find(category_id))
+                .set(categories::is_excluded_from_analysis.eq(is_excluded_from_analysis))
+                .execute(&mut conn)
+                .map_err(|e| {
+                    tracing::error!(
+                        "Failed to update category is_excluded_from_analysis {}: {}",
+                        category_id,
+                        e
+                    );
+                    ApiError::from(e)
+                })?;
+        }
 
         // Return the updated category
         categories::table

--- a/backend/src/schema.rs
+++ b/backend/src/schema.rs
@@ -170,6 +170,7 @@ diesel::table! {
         parent_id -> Nullable<Uuid>,
         created_at -> Timestamptz,
         updated_at -> Timestamptz,
+        is_excluded_from_analysis -> Bool,
     }
 }
 

--- a/backend/src/services/analytics_service.rs
+++ b/backend/src/services/analytics_service.rs
@@ -186,12 +186,33 @@ pub async fn get_category_breakdown(
 
     let transactions = repositories::transaction::list_transactions(pool, user_id, filter).await?;
 
+    // Load the user's categories once so we can both resolve names and skip
+    // categories the user has excluded from analysis. Categories flagged as
+    // excluded drop out of the breakdown entirely; NULL-category (uncategorised)
+    // transactions are never excluded and still contribute.
+    let categories = repositories::category::list_by_user(pool, user_id).await?;
+    let category_names: HashMap<Uuid, String> = categories
+        .iter()
+        .map(|c| (c.id, c.name.clone()))
+        .collect();
+    let excluded_categories: std::collections::HashSet<Uuid> = categories
+        .iter()
+        .filter(|c| c.is_excluded_from_analysis)
+        .map(|c| c.id)
+        .collect();
+
     // Group by category
     let mut category_totals: HashMap<Option<Uuid>, BigDecimal> = HashMap::new();
     let mut total_spending = BigDecimal::from(0);
 
     for result in &transactions {
         let transaction = &result.transaction;
+        // Skip transactions in categories excluded from analysis
+        if let Some(category_id) = transaction.category_id {
+            if excluded_categories.contains(&category_id) {
+                continue;
+            }
+        }
         // Only count expenses (negative amounts)
         if transaction.amount < BigDecimal::from(0) {
             let spending = transaction.amount.abs();
@@ -217,14 +238,7 @@ pub async fn get_category_breakdown(
     let mut breakdown = Vec::new();
 
     for (category_id, total) in category_totals {
-        let category_name = if let Some(id) = category_id {
-            match repositories::category::find_by_id(pool, id).await {
-                Ok(cat) => Some(cat.name),
-                Err(_) => None,
-            }
-        } else {
-            None
-        };
+        let category_name = category_id.and_then(|id| category_names.get(&id).cloned());
 
         let percentage = if total_spending > BigDecimal::from(0) {
             let ratio = &total / &total_spending;

--- a/backend/src/services/budget_service.rs
+++ b/backend/src/services/budget_service.rs
@@ -32,6 +32,19 @@ fn current_period_window(range: &BudgetRange, today: NaiveDate) -> (NaiveDate, N
     (start, end)
 }
 
+/// Fetch the IDs of the user's categories that are excluded from analysis.
+///
+/// Used to keep overall (no-category) budget spend consistent with the
+/// category breakdown, which also drops these categories.
+async fn excluded_category_ids(pool: &DbPool, user_id: Uuid) -> Result<Vec<Uuid>, ApiError> {
+    let categories = repositories::category::list_by_user(pool, user_id).await?;
+    Ok(categories
+        .into_iter()
+        .filter(|c| c.is_excluded_from_analysis)
+        .map(|c| c.id)
+        .collect())
+}
+
 /// Budget status information
 #[derive(Debug, serde::Serialize)]
 pub struct BudgetStatus {
@@ -117,6 +130,11 @@ pub async fn get_budget(
         let start_date = Some(window_start.and_hms_opt(0, 0, 0).unwrap().and_utc());
         let end_date = Some(window_end.and_hms_opt(23, 59, 59).unwrap().and_utc());
 
+        // Categories excluded from analysis are dropped from overall
+        // (no-category) budgets; the repository guards this so category-scoped
+        // budgets are unaffected.
+        let exclude_category_ids = excluded_category_ids(pool, user_id).await?;
+
         // Single query: compute split-adjusted spending grouped by currency
         let spending_by_currency = repositories::budget::calculate_spending_by_currency(
             pool,
@@ -125,6 +143,7 @@ pub async fn get_budget(
             account_id,
             start_date,
             end_date,
+            exclude_category_ids,
         )
         .await?;
 
@@ -336,6 +355,11 @@ pub async fn calculate_budget_status(
     let start_date = Some(window_start.and_hms_opt(0, 0, 0).unwrap().and_utc());
     let end_date = Some(window_end.and_hms_opt(23, 59, 59).unwrap().and_utc());
 
+    // Categories excluded from analysis are dropped from overall
+    // (no-category) budgets; the repository guards this so category-scoped
+    // budgets are unaffected.
+    let exclude_category_ids = excluded_category_ids(pool, user_id).await?;
+
     // Single query: compute split-adjusted spending grouped by currency
     let spending_by_currency = repositories::budget::calculate_spending_by_currency(
         pool,
@@ -344,6 +368,7 @@ pub async fn calculate_budget_status(
         account_id,
         start_date,
         end_date,
+        exclude_category_ids,
     )
     .await?;
 

--- a/backend/tests/integration/api/test_categories.rs
+++ b/backend/tests/integration/api/test_categories.rs
@@ -428,6 +428,93 @@ async fn test_update_category_partial() {
     assert_eq!(updated_category.name, "New Name Only");
     assert_eq!(updated_category.icon, Some("🎨".to_string()));
     assert_eq!(updated_category.color, Some("#9B59B6".to_string()));
+    // Exclusion flag defaults to false and is untouched by a partial update
+    assert!(!updated_category.is_excluded_from_analysis);
+}
+
+/// Test toggling the `is_excluded_from_analysis` flag via update.
+///
+/// Verifies that:
+/// - A newly created category defaults to not excluded
+/// - PUT with `is_excluded_from_analysis: true` marks it excluded
+/// - The flag persists and is returned by the list endpoint
+/// - PUT with `is_excluded_from_analysis: false` clears it again
+#[tokio::test]
+async fn test_update_category_exclude_from_analysis() {
+    let server = create_test_server().await;
+    let timestamp = Utc::now().timestamp_nanos_opt().unwrap();
+
+    let auth = register_test_user(
+        &server,
+        &format!("excludeuser_{}", timestamp),
+        &format!("exclude_{}@example.com", timestamp),
+        "SecurePass123!",
+        "Exclude Test User",
+    )
+    .await;
+
+    // Create a category — defaults to not excluded
+    let create_request = json!({
+        "name": "Investments",
+        "icon": "📈",
+        "color": "#16A085"
+    });
+    let create_response =
+        post_authenticated(&server, "/api/v1/categories", &auth.token, &create_request).await;
+    assert_status(&create_response, 201);
+    let category: CategoryResponse = extract_json(create_response);
+    assert!(
+        !category.is_excluded_from_analysis,
+        "New category should default to not excluded"
+    );
+
+    // Mark it excluded from analysis
+    let exclude_request = json!({ "is_excluded_from_analysis": true });
+    let exclude_response = put_authenticated(
+        &server,
+        &format!("/api/v1/categories/{}", category.id),
+        &auth.token,
+        &exclude_request,
+    )
+    .await;
+    assert_status(&exclude_response, 200);
+    let excluded: CategoryResponse = extract_json(exclude_response);
+    assert!(
+        excluded.is_excluded_from_analysis,
+        "Category should be excluded after update"
+    );
+    // Other fields are untouched by the flag-only update
+    assert_eq!(excluded.name, "Investments");
+    assert_eq!(excluded.icon, Some("📈".to_string()));
+
+    // Flag persists via the list endpoint
+    let list_response = get_authenticated(&server, "/api/v1/categories", &auth.token).await;
+    assert_status(&list_response, 200);
+    let categories: Vec<CategoryResponse> = extract_json(list_response);
+    let listed = categories
+        .iter()
+        .find(|c| c.id == category.id)
+        .expect("category should be in list");
+    assert!(
+        listed.is_excluded_from_analysis,
+        "Exclusion flag should persist in list results"
+    );
+
+    // Clear the flag again
+    let include_request = json!({ "is_excluded_from_analysis": false });
+    let include_response = put_authenticated(
+        &server,
+        &format!("/api/v1/categories/{}", category.id),
+        &auth.token,
+        &include_request,
+    )
+    .await;
+    assert_status(&include_response, 200);
+    let included: CategoryResponse = extract_json(include_response);
+    assert!(
+        !included.is_excluded_from_analysis,
+        "Category should no longer be excluded after clearing the flag"
+    );
 }
 
 /// Test that updating a non-existent category fails.

--- a/backend/tests/integration/api/test_dashboard.rs
+++ b/backend/tests/integration/api/test_dashboard.rs
@@ -1154,3 +1154,192 @@ async fn test_get_dashboard_debt_overview() {
         "Total I owe should be 0 (no net negative debts)"
     );
 }
+
+// ============================================================================
+// Excluded-from-analysis Tests
+// ============================================================================
+
+/// Helper to mark a category as excluded from analysis.
+async fn set_category_excluded(server: &TestServer, token: &str, category_id: &str, excluded: bool) {
+    let request = json!({ "is_excluded_from_analysis": excluded });
+    let response = put_authenticated(
+        server,
+        &format!("/api/v1/categories/{}", category_id),
+        token,
+        &request,
+    )
+    .await;
+    assert_status(&response, 200);
+}
+
+/// Test that categories excluded from analysis drop out of the category
+/// breakdown, while uncategorised transactions remain represented.
+#[tokio::test]
+async fn test_dashboard_breakdown_excludes_flagged_category() {
+    let server = create_test_server().await;
+    let timestamp = Utc::now().timestamp_nanos_opt().unwrap();
+
+    let auth = register_test_user(
+        &server,
+        &format!("excl_bd_{}", timestamp),
+        &format!("excl_bd_{}@example.com", timestamp),
+        "SecurePass123!",
+        "Exclude Breakdown User",
+    )
+    .await;
+
+    let groceries = create_test_category(&server, &auth.token, "Groceries").await;
+    let groceries_id = groceries["id"].as_str().unwrap();
+    let investments = create_test_category(&server, &auth.token, "Investments").await;
+    let investments_id = investments["id"].as_str().unwrap();
+
+    let account = create_test_account(&server, &auth.token, "Checking", "CHECKING", 5000.0).await;
+    let account_id = account["id"].as_str().unwrap();
+
+    // Groceries expense (counts), Investments expense (to be excluded),
+    // and an uncategorised expense (must still be represented).
+    create_test_transaction(
+        &server,
+        &auth.token,
+        account_id,
+        -300.0,
+        "Grocery Shopping",
+        Some(groceries_id),
+        None,
+    )
+    .await;
+    create_test_transaction(
+        &server,
+        &auth.token,
+        account_id,
+        -1000.0,
+        "Stock Purchase",
+        Some(investments_id),
+        None,
+    )
+    .await;
+    create_test_transaction(
+        &server,
+        &auth.token,
+        account_id,
+        -50.0,
+        "Misc",
+        None,
+        None,
+    )
+    .await;
+
+    // Mark Investments excluded from analysis
+    set_category_excluded(&server, &auth.token, investments_id, true).await;
+
+    let response = get_authenticated(&server, "/api/v1/dashboard", &auth.token).await;
+    assert_status(&response, 200);
+    let dashboard = extract_dashboard(response);
+    let breakdown = dashboard["category_breakdown"].as_array().unwrap();
+
+    // Investments must be gone
+    assert!(
+        !breakdown
+            .iter()
+            .any(|c| c["category_name"].as_str() == Some("Investments")),
+        "Excluded category should not appear in breakdown"
+    );
+
+    // Groceries still present with its full total
+    let groceries_bd = breakdown
+        .iter()
+        .find(|c| c["category_name"].as_str() == Some("Groceries"))
+        .expect("Groceries should remain");
+    assert_eq!(
+        BigDecimal::from_str(groceries_bd["total"].as_str().unwrap()).unwrap(),
+        BigDecimal::from_str("300").unwrap()
+    );
+
+    // Uncategorised (null category_name) still represented — exclusion must
+    // not be conflated with being uncategorised.
+    let uncategorised = breakdown
+        .iter()
+        .find(|c| c["category_id"].is_null())
+        .expect("Uncategorised bucket should remain");
+    assert_eq!(
+        BigDecimal::from_str(uncategorised["total"].as_str().unwrap()).unwrap(),
+        BigDecimal::from_str("50").unwrap()
+    );
+}
+
+/// Test that an overall (no-category) budget's spend drops transactions in
+/// categories excluded from analysis, while still counting uncategorised ones.
+#[tokio::test]
+async fn test_no_category_budget_spend_excludes_flagged_category() {
+    let server = create_test_server().await;
+    let timestamp = Utc::now().timestamp_nanos_opt().unwrap();
+
+    let auth = register_test_user(
+        &server,
+        &format!("excl_bg_{}", timestamp),
+        &format!("excl_bg_{}@example.com", timestamp),
+        "SecurePass123!",
+        "Exclude Budget User",
+    )
+    .await;
+
+    let groceries = create_test_category(&server, &auth.token, "Groceries").await;
+    let groceries_id = groceries["id"].as_str().unwrap();
+    let investments = create_test_category(&server, &auth.token, "Investments").await;
+    let investments_id = investments["id"].as_str().unwrap();
+
+    let account = create_test_account(&server, &auth.token, "Checking", "CHECKING", 5000.0).await;
+    let account_id = account["id"].as_str().unwrap();
+
+    // 200 groceries + 1000 investments + 50 uncategorised = 1250 total spend.
+    // Excluding investments should leave 200 + 50 = 250.
+    create_test_transaction(
+        &server,
+        &auth.token,
+        account_id,
+        -200.0,
+        "Groceries",
+        Some(groceries_id),
+        None,
+    )
+    .await;
+    create_test_transaction(
+        &server,
+        &auth.token,
+        account_id,
+        -1000.0,
+        "Stock Purchase",
+        Some(investments_id),
+        None,
+    )
+    .await;
+    create_test_transaction(
+        &server,
+        &auth.token,
+        account_id,
+        -50.0,
+        "Misc",
+        None,
+        None,
+    )
+    .await;
+
+    // Overall budget (no category filter)
+    let budget = create_test_budget(&server, &auth.token, "Overall", None, 2000.0).await;
+    let budget_id = budget["id"].as_str().unwrap();
+
+    set_category_excluded(&server, &auth.token, investments_id, true).await;
+
+    let response =
+        get_authenticated(&server, &format!("/api/v1/budgets/{}", budget_id), &auth.token).await;
+    assert_status(&response, 200);
+    let budget_detail: Value = extract_json(response);
+
+    let current_spending =
+        BigDecimal::from_str(budget_detail["current_spending"].as_str().unwrap()).unwrap();
+    assert_eq!(
+        current_spending,
+        BigDecimal::from_str("250").unwrap(),
+        "No-category budget should exclude the flagged category but keep uncategorised"
+    );
+}

--- a/frontend/src/components/categories/CategoryFormModal.tsx
+++ b/frontend/src/components/categories/CategoryFormModal.tsx
@@ -1,5 +1,5 @@
 import { useEffect } from 'react';
-import { Button, HStack, Input, Switch, Text, VStack } from '@chakra-ui/react';
+import { Button, HStack, Input, Switch, VStack } from '@chakra-ui/react';
 import {
   DialogRoot,
   DialogContent,
@@ -59,6 +59,7 @@ export const CategoryFormModal = ({
   const {
     register,
     control,
+    watch,
     handleSubmit,
     formState: { errors },
     reset,
@@ -134,6 +135,18 @@ export const CategoryFormModal = ({
   const isSubmitting = createMutation.isPending || updateMutation.isPending;
   const mutationError = createMutation.error || updateMutation.error;
 
+  // Editing an existing category (vs. creating a new one). The exclude toggle
+  // only makes sense on edit — a brand-new category has nothing to exclude yet,
+  // and the create endpoint does not accept the flag.
+  const isEditing = !!category;
+
+  // State-dependent helper: describe what IS true now, not what would happen.
+  // Label is "Exclude from analysis", so switch ON = excluded.
+  const isExcluded = watch('isExcludedFromAnalysis');
+  const excludeHelperText = isExcluded
+    ? 'Not counted. Still visible in the ledger and on transactions.'
+    : 'Counted in breakdowns and budgets.';
+
   return (
     <DialogRoot open={isOpen} onOpenChange={(e) => !e.open && onClose()} size="lg">
       <DialogBackdrop />
@@ -202,30 +215,27 @@ export const CategoryFormModal = ({
                 </HStack>
               </Field>
 
-              {/* Exclude from analysis */}
-              <Field
-                label="Exclude from analysis"
-                helperText="When on, this category is left out of spending breakdowns and budgeting. Transactions stay in the ledger and can still use it."
-              >
-                <Controller
-                  name="isExcludedFromAnalysis"
-                  control={control}
-                  render={({ field }) => (
-                    <Switch.Root
-                      checked={field.value}
-                      onCheckedChange={(e) => field.onChange(e.checked)}
-                    >
-                      <Switch.HiddenInput onBlur={field.onBlur} ref={field.ref} />
-                      <Switch.Control>
-                        <Switch.Thumb />
-                      </Switch.Control>
-                      <Switch.Label>
-                        <Text fontSize="sm">{field.value ? 'Excluded' : 'Included'}</Text>
-                      </Switch.Label>
-                    </Switch.Root>
-                  )}
-                />
-              </Field>
+              {/* Exclude from analysis — edit only; a new category has nothing
+                  to exclude yet and the create endpoint ignores the flag. */}
+              {isEditing && (
+                <Field label="Exclude from analysis" helperText={excludeHelperText}>
+                  <Controller
+                    name="isExcludedFromAnalysis"
+                    control={control}
+                    render={({ field }) => (
+                      <Switch.Root
+                        checked={field.value}
+                        onCheckedChange={(e) => field.onChange(e.checked)}
+                      >
+                        <Switch.HiddenInput onBlur={field.onBlur} ref={field.ref} />
+                        <Switch.Control>
+                          <Switch.Thumb />
+                        </Switch.Control>
+                      </Switch.Root>
+                    )}
+                  />
+                </Field>
+              )}
             </VStack>
           </form>
         </DialogBody>

--- a/frontend/src/components/categories/CategoryFormModal.tsx
+++ b/frontend/src/components/categories/CategoryFormModal.tsx
@@ -1,5 +1,5 @@
 import { useEffect } from 'react';
-import { Button, HStack, Input, VStack } from '@chakra-ui/react';
+import { Button, HStack, Input, Switch, Text, VStack } from '@chakra-ui/react';
 import {
   DialogRoot,
   DialogContent,
@@ -10,7 +10,7 @@ import {
   DialogCloseTrigger,
   DialogBackdrop,
 } from '@chakra-ui/react';
-import { useForm } from 'react-hook-form';
+import { Controller, useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
 import { Field } from '@/components/ui/field';
@@ -35,6 +35,7 @@ const categorySchema = z.object({
     .string()
     .min(1, 'Color is required')
     .regex(/^#[0-9A-Fa-f]{6}$/, 'Color must be a valid hex code (e.g., #FF5733)'),
+  isExcludedFromAnalysis: z.boolean(),
 });
 
 type CategoryFormData = z.infer<typeof categorySchema>;
@@ -57,6 +58,7 @@ export const CategoryFormModal = ({
 
   const {
     register,
+    control,
     handleSubmit,
     formState: { errors },
     reset,
@@ -66,6 +68,7 @@ export const CategoryFormModal = ({
       name: '',
       icon: '📁',
       color: getRandomColor(),
+      isExcludedFromAnalysis: false,
     },
   });
 
@@ -77,28 +80,32 @@ export const CategoryFormModal = ({
           name: category.name,
           icon: category.icon,
           color: category.color,
+          isExcludedFromAnalysis: category.is_excluded_from_analysis ?? false,
         });
       } else {
         reset({
           name: '',
           icon: '📁',
           color: getRandomColor(),
+          isExcludedFromAnalysis: false,
         });
       }
     }
   }, [isOpen, category, reset]);
 
   const handleFormSubmit = (data: CategoryFormData) => {
-    const categoryData = {
-      name: data.name,
-      icon: data.icon,
-      color: data.color,
-    };
-
     if (category) {
       // Update existing category
       updateMutation.mutate(
-        { id: category.id, data: categoryData },
+        {
+          id: category.id,
+          data: {
+            name: data.name,
+            icon: data.icon,
+            color: data.color,
+            is_excluded_from_analysis: data.isExcludedFromAnalysis,
+          },
+        },
         {
           onSuccess: () => {
             onSuccess();
@@ -107,13 +114,20 @@ export const CategoryFormModal = ({
         }
       );
     } else {
-      // Create new category
-      createMutation.mutate(categoryData, {
-        onSuccess: () => {
-          onSuccess();
-          onClose();
+      // Create new category (exclusion defaults to off; toggled via edit)
+      createMutation.mutate(
+        {
+          name: data.name,
+          icon: data.icon,
+          color: data.color,
         },
-      });
+        {
+          onSuccess: () => {
+            onSuccess();
+            onClose();
+          },
+        }
+      );
     }
   };
 
@@ -186,6 +200,31 @@ export const CategoryFormModal = ({
                     }}
                   />
                 </HStack>
+              </Field>
+
+              {/* Exclude from analysis */}
+              <Field
+                label="Exclude from analysis"
+                helperText="When on, this category is left out of spending breakdowns and budgeting. Transactions stay in the ledger and can still use it."
+              >
+                <Controller
+                  name="isExcludedFromAnalysis"
+                  control={control}
+                  render={({ field }) => (
+                    <Switch.Root
+                      checked={field.value}
+                      onCheckedChange={(e) => field.onChange(e.checked)}
+                    >
+                      <Switch.HiddenInput onBlur={field.onBlur} ref={field.ref} />
+                      <Switch.Control>
+                        <Switch.Thumb />
+                      </Switch.Control>
+                      <Switch.Label>
+                        <Text fontSize="sm">{field.value ? 'Excluded' : 'Included'}</Text>
+                      </Switch.Label>
+                    </Switch.Root>
+                  )}
+                />
               </Field>
             </VStack>
           </form>

--- a/frontend/src/components/categories/CategoryFormModal.tsx
+++ b/frontend/src/components/categories/CategoryFormModal.tsx
@@ -1,5 +1,5 @@
 import { useEffect } from 'react';
-import { Button, HStack, Input, Switch, VStack } from '@chakra-ui/react';
+import { Box, Button, HStack, Input, Switch, Text, VStack } from '@chakra-ui/react';
 import {
   DialogRoot,
   DialogContent,
@@ -216,25 +216,36 @@ export const CategoryFormModal = ({
               </Field>
 
               {/* Exclude from analysis — edit only; a new category has nothing
-                  to exclude yet and the create endpoint ignores the flag. */}
+                  to exclude yet and the create endpoint ignores the flag.
+                  Label and switch share one row (matching the other fields'
+                  label+control rhythm); state-dependent helper sits below. */}
               {isEditing && (
-                <Field label="Exclude from analysis" helperText={excludeHelperText}>
-                  <Controller
-                    name="isExcludedFromAnalysis"
-                    control={control}
-                    render={({ field }) => (
-                      <Switch.Root
-                        checked={field.value}
-                        onCheckedChange={(e) => field.onChange(e.checked)}
-                      >
-                        <Switch.HiddenInput onBlur={field.onBlur} ref={field.ref} />
-                        <Switch.Control>
-                          <Switch.Thumb />
-                        </Switch.Control>
-                      </Switch.Root>
-                    )}
-                  />
-                </Field>
+                <Box>
+                  <HStack justify="space-between" align="center">
+                    <Text fontWeight="medium">Exclude from analysis</Text>
+                    <Controller
+                      name="isExcludedFromAnalysis"
+                      control={control}
+                      render={({ field }) => (
+                        <Switch.Root
+                          checked={field.value}
+                          onCheckedChange={(e) => field.onChange(e.checked)}
+                        >
+                          <Switch.HiddenInput onBlur={field.onBlur} ref={field.ref} />
+                          <Switch.Control>
+                            <Switch.Thumb />
+                          </Switch.Control>
+                          <Switch.Label color={field.value ? 'fg' : 'fg.muted'}>
+                            {field.value ? 'On' : 'Off'}
+                          </Switch.Label>
+                        </Switch.Root>
+                      )}
+                    />
+                  </HStack>
+                  <Text fontSize="sm" color="fg.muted" mt={1}>
+                    {excludeHelperText}
+                  </Text>
+                </Box>
               )}
             </VStack>
           </form>

--- a/frontend/src/components/reports/MonthlyReport.tsx
+++ b/frontend/src/components/reports/MonthlyReport.tsx
@@ -26,19 +26,25 @@ interface MonthlyReportProps {
 export const MonthlyReport = ({ transactions, categoryBreakdown }: MonthlyReportProps) => {
   const colors = ['#3182CE', '#38A169', '#DD6B20', '#E53E3E', '#805AD5', '#D69E2E'];
 
+  // Categories excluded from analysis drop out of the income/expense totals.
+  const analysableTransactions = useMemo(
+    () => transactions.filter((t) => !t.category?.is_excluded_from_analysis),
+    [transactions]
+  );
+
   const metrics = useMemo(() => {
-    const income = transactions
+    const income = analysableTransactions
       .filter((t) => parseFloat(t.amount) > 0)
       .reduce((sum, t) => sum + parseFloat(t.amount), 0);
 
-    const expenses = transactions
+    const expenses = analysableTransactions
       .filter((t) => parseFloat(t.amount) < 0)
       .reduce((sum, t) => sum + Math.abs(parseFloat(t.amount)), 0);
 
     const net = income - expenses;
 
     return { income, expenses, net };
-  }, [transactions]);
+  }, [analysableTransactions]);
 
   const incomeExpensesData = useMemo(
     () => [
@@ -63,7 +69,7 @@ export const MonthlyReport = ({ transactions, categoryBreakdown }: MonthlyReport
   const dailyTrend = useMemo(() => {
     const dailyMap = new Map<string, number>();
 
-    transactions.forEach((t) => {
+    analysableTransactions.forEach((t) => {
       const day = formatDate(t.date, 'short');
       const amount = Math.abs(parseFloat(t.amount));
       if (parseFloat(t.amount) < 0) {
@@ -74,7 +80,7 @@ export const MonthlyReport = ({ transactions, categoryBreakdown }: MonthlyReport
     return Array.from(dailyMap.entries())
       .map(([day, amount]) => ({ day, amount }))
       .slice(0, 10);
-  }, [transactions]);
+  }, [analysableTransactions]);
 
   return (
     <VStack gap={6} alignItems="stretch">

--- a/frontend/src/hooks/api/useEnrichedTransactions.ts
+++ b/frontend/src/hooks/api/useEnrichedTransactions.ts
@@ -54,6 +54,7 @@ export default function useEnrichedTransactions(
               id: category.id,
               name: category.name,
               icon: category.icon,
+              is_excluded_from_analysis: category.is_excluded_from_analysis,
             }
           : undefined,
         notes: transaction.notes,

--- a/frontend/src/hooks/api/useUpdateCategory.ts
+++ b/frontend/src/hooks/api/useUpdateCategory.ts
@@ -21,6 +21,7 @@ export default function useUpdateCategory() {
         icon: string;
         color: string;
         parent_category_id: string;
+        is_excluded_from_analysis: boolean;
       }>;
     }) => updateCategory(id, data),
     onSuccess: (_, variables) => {

--- a/frontend/src/pages/Transactions.tsx
+++ b/frontend/src/pages/Transactions.tsx
@@ -163,7 +163,13 @@ export const TransactionsPage = () => {
       return { income: 0, expenses: 0 };
     }
 
-    const income = filteredTransactions
+    // Categories excluded from analysis drop out of the income/expense
+    // totals, but the transactions themselves stay in the list below.
+    const analysable = filteredTransactions.filter(
+      (t) => !t.category?.is_excluded_from_analysis
+    );
+
+    const income = analysable
       .filter((t) => parseFloat(t.amount) > 0)
       .reduce((sum, t) => {
         const amount = parseFloat(t.amount);
@@ -172,7 +178,7 @@ export const TransactionsPage = () => {
       }, 0);
 
     const expenses = Math.abs(
-      filteredTransactions
+      analysable
         .filter((t) => parseFloat(t.amount) < 0)
         .reduce((sum, t) => {
           const amount = parseFloat(t.amount);

--- a/frontend/src/services/categoryService.ts
+++ b/frontend/src/services/categoryService.ts
@@ -40,6 +40,7 @@ export async function updateCategory(
     icon: string;
     color: string;
     parent_category_id: string;
+    is_excluded_from_analysis: boolean;
   }>
 ): Promise<Category> {
   const response = await apiClient.put<Category>(`/categories/${id}`, data);

--- a/frontend/src/types/models.ts
+++ b/frontend/src/types/models.ts
@@ -144,6 +144,7 @@ export interface EnrichedTransaction {
     id: string;
     name: string;
     icon: string;
+    is_excluded_from_analysis?: boolean;
   };
   splits?: TransactionSplit[];
   notes?: string;

--- a/frontend/src/types/models.ts
+++ b/frontend/src/types/models.ts
@@ -33,6 +33,7 @@ export interface Category {
   parent_category_id?: string;
   transaction_count: number;
   created_at: string;
+  is_excluded_from_analysis?: boolean;
 }
 
 // Person types


### PR DESCRIPTION
## Summary

Adds the ability to mark categories as **excluded from analysis**, per Abhijeet's request. Excluded categories drop out of spending analysis everywhere, but the transactions themselves stay in the ledger and the category stays assignable.

Decisions this implements:
- **D2 = broad**: excluded categories are removed from the category breakdown, from overall (no-category) budget spend, AND from the top-line income/expense totals on Transactions and Reports — so no screen shows a number that silently includes them.
- **D3 = Categories page**: the toggle lives on the existing category form (not a new Settings tab).
- **D4 = retroactive/immediate**: it's a query-time filter, so it takes effect immediately over historical data.

**Uncategorised ≠ excluded**: transactions with no category are never excluded and continue to count everywhere (verified against current behaviour — no-category budgets and the breakdown already include them).

## Changes

**Backend**
- Migration `add_excluded_from_analysis_to_categories`: `is_excluded_from_analysis BOOLEAN NOT NULL DEFAULT FALSE` + partial index; reversible `down.sql`.
- Flag added to `Category` / `UpdateCategory` / `UpdateCategoryRequest` / `CategoryResponse` and `schema.rs`.
- `PUT /categories/:id` accepts and persists the flag.
- `analytics_service::get_category_breakdown`: skips excluded categories (and now resolves category names from a single `list_by_user` fetch instead of per-row lookups).
- `budget::calculate_spending_by_currency`: drops excluded categories **only for no-category budgets** (a category-scoped budget targeting an excluded category is honoured); never affects NULL-category rows.

**Frontend**
- "Exclude from analysis" switch in `CategoryFormModal` (Categories page).
- `is_excluded_from_analysis` propagated through `useEnrichedTransactions` and the `EnrichedTransaction.category` type.
- Income/expense reducers on `Transactions` and `MonthlyReport` (and the Reports daily-trend chart) skip excluded categories — the transaction list itself is untouched, so excluded rows still show in the ledger.

## Testing

- New integration tests: toggle flag via API (default off → on → persists in list → off); breakdown excludes a flagged category while keeping Groceries and the Uncategorised bucket; no-category budget spend = 250 not 1250 after excluding Investments (uncategorised still counted).
- Ran against a real Postgres: **4 new tests pass**, plus regression on `test_dashboard` (14), `test_budgets` (30), `test_budget_spending` (7), `test_categories` (19) — all green.
- Frontend `tsc` + `eslint` clean.

## Notes / possible follow-ups

- New categories default to not-excluded; the flag is toggled via edit (create form doesn't send it).
- Not touched: net worth (category-independent by design). No export endpoints exist to update.
- Backend was built/tested in a Rust 1.90 container (no local toolchain); the pre-commit hook's `cargo test` + Playwright were not run locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
