### PR TITLE
feat: show the deployed version in the UI and behind auth (closes #83)

### DIFF
--- a/.github/workflows/beta-image.yml
+++ b/.github/workflows/beta-image.yml
@@ -65,6 +65,12 @@ jobs:
           file: ./Dockerfile
           platforms: ${{ matrix.platform }}
           labels: ${{ steps.meta.outputs.labels }}
+          # Version display (issue #83): a beta build is not a release, so it
+          # reports APP_VERSION=beta plus the commit it was built from, e.g.
+          # "beta (a1b2c3d)". github.sha is the branch head being built.
+          build-args: |
+            APP_VERSION=beta
+            GIT_SHA=${{ github.sha }}
           cache-from: type=gha,scope=beta-${{ matrix.platform }}
           cache-to: type=gha,mode=max,scope=beta-${{ matrix.platform }}
           outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -61,6 +61,13 @@ jobs:
           file: ./Dockerfile
           platforms: ${{ matrix.platform }}
           labels: ${{ steps.meta.outputs.labels }}
+          # Version display (issue #83): APP_VERSION MUST come from the SAME
+          # value that feeds the image label (steps.meta.outputs.version), so
+          # the displayed version and the org.opencontainers.image.version label
+          # can never disagree. Do not derive the version a second way here.
+          build-args: |
+            APP_VERSION=${{ steps.meta.outputs.version }}
+            GIT_SHA=${{ github.sha }}
           cache-from: type=gha,scope=${{ matrix.platform }}
           cache-to: type=gha,mode=max,scope=${{ matrix.platform }}
           outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true

--- a/Dockerfile
+++ b/Dockerfile
@@ -103,6 +103,15 @@ USER appuser
 # Note: The application uses SERVER_PORT env var (default: 13153)
 EXPOSE 13153
 
+# Version display (issue #83): CI passes the release tag and commit sha as
+# build args; promote them to runtime env so the backend can report them on
+# /health. Unset (e.g. a plain local `docker build`) leaves them empty and the
+# backend falls back to "dev"/"unknown" rather than showing a wrong number.
+ARG APP_VERSION
+ARG GIT_SHA
+ENV APP_VERSION=${APP_VERSION} \
+    GIT_SHA=${GIT_SHA}
+
 # Set environment variables with sensible defaults
 ENV RUST_LOG=info \
     SERVER_HOST=0.0.0.0 \

--- a/backend/src/api/routes.rs
+++ b/backend/src/api/routes.rs
@@ -96,6 +96,8 @@ pub fn create_router(state: AppState) -> Router {
         .route("/auth/me", get(handlers::auth::get_current_user))
         // Dashboard (no scope check - read-only summary)
         .route("/dashboard", get(handlers::dashboard::get_summary))
+        // Deployed build version (no scope check - authenticated read-only, issue #83)
+        .route("/version", get(handlers::version::get))
         // Exchange rates (no scope check - read-only utility)
         .route(
             "/exchange-rates",

--- a/backend/src/handlers/health.rs
+++ b/backend/src/handlers/health.rs
@@ -12,6 +12,11 @@ use crate::AppState;
 ///
 /// Returns 200 OK with `{"status": "healthy"}` if the DB pool is reachable,
 /// or 503 Service Unavailable with `{"status": "unhealthy", "error": "..."}` otherwise.
+///
+/// Deliberately does NOT report the build version: this endpoint is public
+/// (outside `/api/v1` auth), and the repo is public, so exposing the commit sha
+/// here would point anyone at the exact deployed source. Version/commit live on
+/// the authenticated `GET /api/v1/version` route instead (issue #83).
 pub async fn check(State(state): State<AppState>) -> (StatusCode, Json<Value>) {
     match state.db.get() {
         Ok(_conn) => (

--- a/backend/src/handlers/mod.rs
+++ b/backend/src/handlers/mod.rs
@@ -23,3 +23,4 @@ pub mod splitpro_integration;
 pub mod splitwise_integration;
 pub mod transactions;
 pub mod transfers;
+pub mod version;

--- a/backend/src/handlers/version.rs
+++ b/backend/src/handlers/version.rs
@@ -1,0 +1,22 @@
+//! Build version handler (issue #83).
+//!
+//! Reports the deployed build's release tag and commit sha. This route is
+//! AUTHENTICATED (mounted inside `/api/v1`, behind `require_auth`) rather than
+//! on the public `/health`, because the repo is public: exposing the commit sha
+//! unauthenticated would point anyone at the exact deployed source. The values
+//! are baked into the image at build time; see `crate::version`.
+
+use axum::Json;
+use serde_json::{Value, json};
+
+/// GET /api/v1/version
+///
+/// Returns `{ "version": "0.21.0", "commit": "a232171" }` for a release build,
+/// or `{ "version": "dev", "commit": "unknown" }` for a local build with no
+/// build args supplied.
+pub async fn get() -> Json<Value> {
+    Json(json!({
+        "version": crate::version::APP_VERSION.as_str(),
+        "commit": crate::version::GIT_SHA.as_str(),
+    }))
+}

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -33,6 +33,7 @@ pub mod db;
 pub mod models;
 pub mod schema;
 pub mod types;
+pub mod version;
 
 // API and routing
 pub mod api;

--- a/backend/src/version.rs
+++ b/backend/src/version.rs
@@ -1,0 +1,34 @@
+//! Build version information for the running binary (issue #83).
+//!
+//! The values come from build args baked into the image by CI (see the
+//! Dockerfile and docker-publish workflow), promoted to runtime env. They are
+//! read ONCE at startup. When unset — for example a plain local `cargo run` or
+//! a `docker build` with no args — they fall back to honest placeholders
+//! (`dev` / `unknown`) rather than an invented or stale-looking number. They
+//! are deliberately NOT sourced from `CARGO_PKG_VERSION`, which is a stale
+//! placeholder in this repo and would display a wrong version.
+
+use std::sync::LazyLock;
+
+/// The release version this image was built from (e.g. `0.21.0`), or `dev` when
+/// built outside CI.
+pub static APP_VERSION: LazyLock<String> =
+    LazyLock::new(|| non_empty_env("APP_VERSION").unwrap_or_else(|| "dev".to_string()));
+
+/// The short git commit the image was built from (e.g. `a232171`), or `unknown`
+/// when built outside CI.
+pub static GIT_SHA: LazyLock<String> = LazyLock::new(|| {
+    non_empty_env("GIT_SHA")
+        .map(|s| s.chars().take(7).collect::<String>())
+        .unwrap_or_else(|| "unknown".to_string())
+});
+
+/// Read an env var, treating an unset OR empty value as absent. Build args that
+/// are declared but never supplied arrive as empty strings, which must fall
+/// back rather than render blank.
+fn non_empty_env(key: &str) -> Option<String> {
+    match std::env::var(key) {
+        Ok(v) if !v.trim().is_empty() => Some(v),
+        _ => None,
+    }
+}

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -14,6 +14,7 @@ import {
   MdSettings,
 } from 'react-icons/md';
 import { useAuth } from '@/contexts/AuthContext';
+import { useVersion } from '@/hooks';
 import { getInitials } from '@/utils/formatters/text';
 
 interface SidebarProps {
@@ -56,6 +57,41 @@ const NavItem = ({ icon: IconComponent, label, to, onClick, isCollapsed }: NavIt
         </Box>
       )}
     </NavLink>
+  );
+};
+
+/**
+ * Deployed build version (issue #83), read from the authenticated
+ * /api/v1/version endpoint. Shows the release tag ("v0.21.0"), or "vdev" for a
+ * local build. The commit sha stays on the endpoint and is not shown here; the
+ * tag is what is read at a glance.
+ *
+ * The line is HIDDEN entirely when there is no version to show — no session,
+ * still loading, or the request failed — rather than rendering a blank or an
+ * error next to a "Version" label, which would look like a broken app. It only
+ * appears once a real version has been fetched.
+ */
+const VersionLine = ({ enabled, isCollapsed }: { enabled: boolean; isCollapsed?: boolean }) => {
+  const { data } = useVersion(enabled);
+
+  // Nothing to show yet (unauthenticated, loading, or errored): render nothing.
+  if (!data?.version) {
+    return null;
+  }
+
+  return (
+    <Box
+      px={isCollapsed ? 2 : 4}
+      py={2}
+      borderTopWidth="1px"
+      borderColor="border"
+      display="flex"
+      justifyContent="center"
+    >
+      <Text fontSize="xs" color="fg.muted" title={`v${data.version}`} truncate>
+        {`v${data.version}`}
+      </Text>
+    </Box>
   );
 };
 
@@ -219,6 +255,9 @@ export const Sidebar = ({ onClose, isCollapsed = false }: SidebarProps) => {
           )}
         </Box>
       )}
+
+      {/* Deployed version (issue #83) */}
+      <VersionLine enabled={!!user} isCollapsed={isCollapsed} />
     </Box>
   );
 };

--- a/frontend/src/hooks/api/index.ts
+++ b/frontend/src/hooks/api/index.ts
@@ -6,6 +6,7 @@ export { default as useCreateDebtTransaction } from './useCreateDebtTransaction'
 export { default as useCreateTransfer } from './useCreateTransfer';
 export { default as useConvertToTransfer } from './useConvertToTransfer';
 export { default as useConvertCandidates } from './useConvertCandidates';
+export { default as useVersion } from './useVersion';
 export { default as useUpdateTransaction } from './useUpdateTransaction';
 export { default as useDeleteTransaction } from './useDeleteTransaction';
 export { default as useTrashTransactions } from './useTrashTransactions';

--- a/frontend/src/hooks/api/useVersion.ts
+++ b/frontend/src/hooks/api/useVersion.ts
@@ -1,0 +1,25 @@
+import { useQuery } from '@tanstack/react-query';
+import { getVersion } from '@/services/versionService';
+
+/**
+ * Fetch the deployed build's version (issue #83) from the authenticated
+ * /api/v1/version endpoint.
+ *
+ * Pass `enabled` from the caller's auth state so it does not fire (and 401) on
+ * the login screen or after the session expires. Cached indefinitely, since the
+ * version only changes on a redeploy which reloads the page. The caller hides
+ * the version line entirely when there is no data rather than rendering a
+ * broken value.
+ *
+ * @param enabled - whether there is an authenticated session
+ * @returns React Query result of the version payload
+ */
+export default function useVersion(enabled: boolean) {
+  return useQuery({
+    queryKey: ['version'],
+    queryFn: getVersion,
+    enabled,
+    staleTime: Infinity,
+    retry: 1,
+  });
+}

--- a/frontend/src/services/versionService.ts
+++ b/frontend/src/services/versionService.ts
@@ -1,0 +1,23 @@
+/**
+ * Version service (issue #83)
+ *
+ * Fetches the deployed build's version and commit from the AUTHENTICATED
+ * /api/v1/version endpoint. It is behind auth (not on public /health) because
+ * the repo is public and the commit sha points at deployed source. Goes through
+ * the standard apiClient, which carries the /api/v1 base and the auth token.
+ */
+
+import apiClient from '@/lib/axios';
+
+export interface VersionResponse {
+  /** Release tag (e.g. "0.21.0") or "dev" for a local build. */
+  version: string;
+  /** Short git commit (e.g. "a232171") or "unknown" for a local build. */
+  commit: string;
+}
+
+/** Fetch the deployed build's version. Requires an authenticated session. */
+export async function getVersion(): Promise<VersionResponse> {
+  const response = await apiClient.get<VersionResponse>('/version');
+  return response.data;
+}


### PR DESCRIPTION
## Summary

Show the deployed build's version in the UI and on an authenticated endpoint (closes #83), so "what is running" can be answered without inspecting containers.

### How the version is sourced (and why it cannot lie)
- CI passes the release tag and commit sha into the image as build args. `APP_VERSION` comes from the SAME `steps.meta.outputs.version` that feeds the `org.opencontainers.image.version` label, so the displayed version and the image label cannot diverge. `GIT_SHA` is `github.sha`.
- The Dockerfile promotes those args to runtime env in the final stage; the backend reads them once at startup.
- Fallbacks are explicit: `APP_VERSION` unset -> `dev`, `GIT_SHA` unset -> `unknown`. Never blank, and deliberately NOT `CARGO_PKG_VERSION` (a stale `0.1.0` placeholder that would display a wrong number).

### Behind auth, not on /health
- Version and commit are served from a NEW authenticated route, `GET /api/v1/version` (inside the `/api/v1` group, behind `require_auth`). The repo is public, so an unauthenticated commit sha would point anyone at the exact deployed source; this keeps that behind a session.
- `/health` is UNCHANGED (still `{status, service}`), so the public endpoint discloses nothing new and the Docker healthcheck is unaffected.

### What it shows
- `GET /api/v1/version` returns `{version, commit}`. Verified at runtime: with build env set it returns `{"version":"0.21.0","commit":"1b63548"}`; unauthenticated it returns 401; with no build env it returns `{"version":"dev","commit":"unknown"}`.
- The sidebar shows the tag only (`v0.21.0`) under the user block, reading `/api/v1/version`. The commit stays on the endpoint as a debugging detail.
- Unauthenticated / loading / error handling: the version line is HIDDEN entirely (renders nothing) until a real version is fetched, so it never shows a blank or an error next to a "Version" label on the login screen or after a session expires.

### Trust property
- It describes the ARTEFACT (the image), not the running container. During a stuck deploy it keeps showing the OLD version honestly rather than claiming the new one, which is the desirable behaviour.

### Scope
- Backend: new `version` module + `GET /api/v1/version` handler/route; `/health` unchanged. Frontend: new `versionService` + `useVersion` hook (enabled only with a session) + a sidebar line. CI: build-args on docker-publish and beta-image. Dockerfile: ARG/ENV in the final stage. No migration.

### Version differs by pipeline (expected, not a bug)
The two build pipelines pass different `APP_VERSION` values by design: `docker-publish` (releases) passes the git tag, so a released build shows `v0.21.0`; `beta-image` passes `APP_VERSION=beta`, so a beta build deliberately shows `vbeta` in the sidebar with the branch commit on `/api/v1/version`. This is intentional so a beta preview is visibly not a release; seeing `vbeta` on beta is correct, not a broken version display.