### PR TITLE
fix: bake bare semver into APP_VERSION so the UI shows v0.22.0 not vv0.22.0

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -51,6 +51,12 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          # Emit a BARE semver for steps.meta.outputs.version (0.22.0, not the
+          # raw ref v0.22.0), matching the merge job and the ghcr tag. This
+          # feeds APP_VERSION (issue #83); without it the default was the ref,
+          # which baked APP_VERSION=v0.22.0 and rendered "vv0.22.0" in the UI.
+          tags: |
+            type=semver,pattern={{version}}
 
       # Build and push by digest (no tag yet — tags applied in merge job)
       - name: Build and push by digest


### PR DESCRIPTION
## Summary

Fixes a version-display formatting bug found while verifying the v0.22.0 release image (issue #83 follow-up): the sidebar would render `vv0.22.0` (double `v`) on a real release.

## Cause

The `docker-publish` build job's `metadata-action` step had no `tags:` block, so `steps.meta.outputs.version` defaulted to the raw git ref (`v0.22.0`). That value is passed as the `APP_VERSION` build arg, so the image baked `APP_VERSION=v0.22.0`. The sidebar prepends its own `v` for display, producing `vv0.22.0`. The `merge` job in the same workflow already used `type=semver,pattern={{version}}` (yielding `0.22.0`), so the two steps disagreed for the same build.

## Fix

Add `tags: type=semver,pattern={{version}}` to the build job's `metadata-action`, so `steps.meta.outputs.version` is the bare semver `0.22.0`, matching the merge job and the ghcr tag. `APP_VERSION` is then a bare identifier, the UI's leading `v` is correct, and `/api/v1/version` returns `0.22.0`. Fixed at the source (the two steps now agree) rather than stripping downstream.

## Notes

- Beta is unaffected: its `APP_VERSION` is the literal `beta` (not from a tag), so it renders `vbeta` as before. This bug was invisible on beta by construction, which is why it was caught by reading the release image's baked env rather than a beta check.
- Build-config only; no runtime code change, no migration.
